### PR TITLE
mesh: update torch & fix error

### DIFF
--- a/fealpy/mesh/Mesh2d.py
+++ b/fealpy/mesh/Mesh2d.py
@@ -1,8 +1,9 @@
-import numpy as np
-
-from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, spdiags, eye, tril, triu
-from ..common import ranges
 from types import ModuleType
+
+import numpy as np
+from scipy.sparse import coo_matrix, csr_matrix
+
+from ..common import ranges
 from .Mesh import Mesh
 
 class Mesh2d(Mesh):
@@ -52,7 +53,7 @@ class Mesh2d(Mesh):
         elif etype in {'node', 0}:
             bc = node[index]
         else:
-            raise ValueError('the entity `{}` is not correct!'.format(entity))
+            raise ValueError('the entity `{}` is not correct!'.format(etype))
         return bc
 
     def node_size(self):

--- a/fealpy/mesh/Mesh2d.py
+++ b/fealpy/mesh/Mesh2d.py
@@ -103,7 +103,7 @@ class Mesh2d(Mesh):
         node = self.entity('node')
         edge = self.entity('edge')
         v = node[edge[index,1],:] - node[edge[index,0],:]
-        length = np.linalg.norm(v, axis=1))
+        length = np.linalg.norm(v, axis=1)
         return length
 
     def cell_area(self, index=np.s_[:]):


### PR DESCRIPTION
更正：
- Mesh2d.py 中 `edge_length` 方法中有一个地方多了一个右括号，已去除
- 删除了 Mesh2d.py 中多余的导入
- `entity_barycenter` 方法里有一个 etype 写成了 entity

更新：
- 在 mesh/torch/mesh.py 中按建议改用了更高效的写法
