### PR TITLE
Plotting module for mesh

### DIFF
--- a/fealpy/mesh/mesh_base/__init__.py
+++ b/fealpy/mesh/mesh_base/__init__.py
@@ -3,3 +3,4 @@ Provide ABCs for mesh
 """
 from .mesh import Mesh
 from .topology import Mesh1d, Mesh2d, Mesh3d
+from .plot import Plotable

--- a/fealpy/mesh/mesh_base/plot.py
+++ b/fealpy/mesh/mesh_base/plot.py
@@ -1,0 +1,135 @@
+"""
+Provide the `add_plot` API in Plotable.
+"""
+
+from typing import Optional, Union
+import numpy as np
+from .mesh import Mesh
+
+
+class Plotable():
+    """
+    @brief Base class for plotable meshes. Inherit this class to obtain several\
+           plotting methods.
+
+    Before using these plotting methods, call the class method
+    `MeshClass.set_ploter()` to chose a proper ploter for the mesh type.
+    For example, specity a plotter for a mesh type named 'TriangleMesh':
+    ```
+        class TriangleMesh(Mesh2d, Plotable):
+            # codes for mesh ...
+            ...
+
+        TriangleMesh.set_ploter('unique str key of the ploter')
+    ```
+    Here `MyPloter` is a subclass of `MeshPloter`. Then, instances of `TriangleMesh`
+    may call methods such as `add_plot()` to draw the mesh.
+
+    @seealso: MeshPloter.
+    """
+    _ploter_class: Optional[str] = None
+
+    @property
+    def add_plot(self):
+        if not isinstance(self, Mesh):
+            raise TypeError("Plotable only works for mesh type,"
+                            f"but got {self.__class__.__name__}.")
+
+        from ..plotting.classic import get_ploter
+
+        if self._ploter_class is not None:
+            return get_ploter(self._ploter_class)(self)
+        else:
+            raise Exception('MeshPloter of the type of mesh should be specified'
+                            'before drawing. If a mesh is inherited from Plotable,'
+                            'use MeshClass.set_ploter(MeshPloterClass) to specify.')
+
+    @classmethod
+    def set_ploter(cls, ploter: str):
+        cls._ploter_class = ploter
+
+    def find_entity(self, axes, etype: Union[int, str], index=np.s_[:],
+                    showindex: bool=False, color='r', markersize=20,
+                    fontcolor='k', fontsize=24):
+        """
+        @brief Show the barycenter of each entity.
+        """
+        from ..plotting import artist as A
+        from ..plotting.classic import array_color_map
+
+        if not isinstance(self, Mesh):
+            raise TypeError("Plotable only works for mesh type,"
+                            f"but got {self.__class__.__name__}.")
+
+        bc = self.entity_barycenter(etype=etype, index=index)
+        if bc.ndim == 1:
+            bc = bc[:, None]
+
+        if isinstance(color, np.ndarray) and np.isreal(color[0]):
+            mapper = array_color_map(color, 'rainbow')
+            color = mapper.to_rgba(color)
+
+        A.scatter(axes=axes, points=bc, color=color, markersize=markersize)
+        if showindex:
+            if index == np.s_[:]:
+                index = np.arange(bc.shape[0])
+            elif isinstance(index, np.ndarray):
+                if (index.dtype is np.bool_):
+                    index, = np.nonzero(index)
+            else:
+                raise TypeError("Unknown index format.")
+            A.show_index(axes=axes, location=bc, number=index,
+                         fontcolor=fontcolor, fontsize=fontsize)
+
+    def find_node(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='r', markersize=20,
+            fontsize=16, fontcolor='r',
+            multi_index=None):
+        return self.find_entity(
+                axes, 'node', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_edge(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='g', markersize=22,
+            fontsize=18, fontcolor='g'):
+        return self.find_entity(
+                axes, 'edge', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_face(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='b', markersize=24,
+            fontsize=20, fontcolor='b'):
+        return self.find_entity(
+                axes, 'face', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_cell(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='y', markersize=26,
+            fontsize=22, fontcolor='y'):
+        return self.find_entity(
+                axes, 'cell', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)

--- a/fealpy/mesh/plotting/__init__.py
+++ b/fealpy/mesh/plotting/__init__.py
@@ -1,0 +1,3 @@
+
+from .classic import Plotable, MeshPloter
+from .artist import show_index, scatter, line, poly

--- a/fealpy/mesh/plotting/__init__.py
+++ b/fealpy/mesh/plotting/__init__.py
@@ -2,6 +2,6 @@
 Provide plotting supports for the mesh module, based on matplotlib.
 """
 
-from .classic import Plotable, MeshPloter
-from .classic import AddPlot1d, AddPlot2dHomo, AddPlot2dPoly, AddPlot3d
+from .classic import MeshPloter, get_ploter
+from .classic import AddPlot1d, AddPlot2dHomo, AddPlot2dPoly, AddPlot3dHomo
 from .artist import show_index, scatter, line, poly, poly_

--- a/fealpy/mesh/plotting/__init__.py
+++ b/fealpy/mesh/plotting/__init__.py
@@ -1,3 +1,7 @@
+"""
+Provide plotting supports for the mesh module, based on matplotlib.
+"""
 
 from .classic import Plotable, MeshPloter
-from .artist import show_index, scatter, line, poly
+from .classic import AddPlot1d, AddPlot2dHomo, AddPlot2dPoly, AddPlot3d
+from .artist import show_index, scatter, line, poly, poly_

--- a/fealpy/mesh/plotting/artist.py
+++ b/fealpy/mesh/plotting/artist.py
@@ -1,0 +1,142 @@
+"""
+Provide plotting tools for given points with structure.
+"""
+
+from numpy.typing import NDArray
+from matplotlib.axes import Axes
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+
+
+def _validate_geo_dim(axes: Axes, points: NDArray):
+    if points.ndim != 2:
+        raise ValueError("Arg 'points' should have 2 dimensions.")
+
+    (NN, GD) = points.shape
+
+    if isinstance(axes, Axes3D):
+        if GD == 3:
+            return points
+        elif GD in {1, 2}:
+            tailer = np.zeros((NN, 3-GD), dtype=points.dtype)
+            return np.concatenate([points, tailer], axis=-1)
+
+    elif isinstance(axes, Axes):
+        if GD == 3:
+            raise ValueError("Can not plot 3d points in 2d axes.")
+        elif GD == 2:
+            return points
+        elif GD == 1:
+            tailer = np.zeros((NN, 2-GD), dtype=points.dtype)
+            return np.concatenate([points, tailer], axis=-1)
+
+    raise ValueError(f"Plotting for {GD}-d points has not been implemented.")
+
+
+def show_index(axes: Axes, location: NDArray, number: NDArray, fontcolor='k',
+               fontsize=24):
+    """
+    @brief Show index numbers in the given locations in 2d or 3d.
+    """
+    GD = location.shape[-1]
+    loc = _validate_geo_dim(axes, location)
+    if GD == 3:
+        for i, idx in enumerate(number):
+            axes.text(loc[i, 0], loc[i, 1], loc[i, 2], str(idx),
+                multialignment='center', fontsize=fontsize,
+                color=fontcolor)
+
+    else:
+        for i, idx in enumerate(number):
+            axes.text(
+                loc[i, 0], loc[i, 1], str(idx),
+                multialignment='center',
+                fontsize=fontsize, color=fontcolor)
+
+
+def show_multi_index():
+    pass
+
+
+def scatter(axes: Axes, points: NDArray, color, markersize):
+    """
+    @brief Show points in the axes.
+
+    @param points: An NDArray[float] containing positions with shape (NN, GD) where\
+                   NN is the number of points and GD is their geometry dimension.
+    @param color: Color of the node markers.
+    @param markersize: The size of the node markers.
+
+    @return: PathCollection.
+    """
+    GD = points.shape[-1]
+    loc = _validate_geo_dim(axes, points)
+
+    if GD == 3:
+        return axes.scatter(
+            loc[:, 0], loc[:, 1], loc[:, 2],
+            color=color, s=markersize
+        ),
+    else:
+        return axes.scatter(
+            loc[:, 0], loc[:, 1],
+            color=color, s=markersize
+        )
+
+
+def line(axes: Axes, points: NDArray, struct: NDArray, color, linewidths):
+    """
+    @brief Show lines in the axes.
+
+    @param points: An NDArray[float] containing positions of the vertices.
+    @param struct: An NDArray[int] of indices of vertices in two ends of an edge.\
+                   It should be with shape (NE, 2) where NE matches the number of\
+                   edges and 2 means there are two ends in each edge.
+    @param color: Color of lines.
+    @param linewidths: Widths of lines.
+
+    @return: LineCollection or Line3DCollection.
+    """
+    GD = points.shape[-1]
+    loc = _validate_geo_dim(axes, points)
+    vts = loc[struct, :]
+
+    if GD == 3:
+        from mpl_toolkits.mplot3d.art3d import Line3DCollection
+        lines = Line3DCollection(vts, linewidths=linewidths, colors=color)
+    else:
+        from matplotlib.collections import LineCollection
+        lines = LineCollection(vts, linewidths=linewidths, colors=color)
+
+    return axes.add_collection(lines)
+
+
+def poly(axes: Axes, points: NDArray, struct: NDArray, edgecolor,
+         cellcolor, linewidths, alpha):
+    """
+    @brief Show polygons in the axes.
+
+    @param points: An NDArray[float] containing positions of the vertices.
+    @param struct: An NDArray[int] of indices of nodes in every polygons.\
+                   It should be with shape (NC, NVC) where NC matches the number\
+                   cells and NVC(>=3) is the number of vertices in each cell.
+
+    @return: PolyCollection or Poly3DCollection.
+    """
+    GD = points.shape[-1]
+    loc = _validate_geo_dim(axes, points)
+    vts = loc[struct, :]
+
+    if GD == 3:
+        from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+        poly = Poly3DCollection(vts)
+    else:
+        from matplotlib.collections import PolyCollection
+        poly = PolyCollection(vts)
+
+    poly.set_edgecolor(edgecolor)
+    poly.set_linewidth(linewidths)
+    poly.set_facecolor(cellcolor)
+    poly.set_alpha(alpha)
+
+    return axes.add_collection(collection=poly)

--- a/fealpy/mesh/plotting/artist.py
+++ b/fealpy/mesh/plotting/artist.py
@@ -2,6 +2,7 @@
 Provide plotting tools for given points with structure.
 """
 
+from typing import Sequence
 from numpy.typing import NDArray
 from matplotlib.axes import Axes
 from mpl_toolkits.mplot3d import Axes3D
@@ -112,9 +113,9 @@ def line(axes: Axes, points: NDArray, struct: NDArray, color, linewidths):
 
 
 def poly(axes: Axes, points: NDArray, struct: NDArray, edgecolor,
-         cellcolor, linewidths, alpha):
+         cellcolor, linewidths=0.1, alpha=1.0):
     """
-    @brief Show polygons in the axes.
+    @brief Show homogeneous polygons in the axes.
 
     @param points: An NDArray[float] containing positions of the vertices.
     @param struct: An NDArray[int] of indices of nodes in every polygons.\
@@ -133,6 +134,35 @@ def poly(axes: Axes, points: NDArray, struct: NDArray, edgecolor,
     else:
         from matplotlib.collections import PolyCollection
         poly = PolyCollection(vts)
+
+    poly.set_edgecolor(edgecolor)
+    poly.set_linewidth(linewidths)
+    poly.set_facecolor(cellcolor)
+    poly.set_alpha(alpha)
+
+    return axes.add_collection(collection=poly)
+
+
+def poly_(axes: Axes, points: NDArray, struct_seq: Sequence[NDArray],
+          edgecolor, cellcolor, linewidths=0.1, alpha=1.0):
+    """
+    @brief Show polygons (may have different shape of cells) in the axes.
+    """
+    GD = points.shape[-1]
+    if GD != 2:
+        raise NotImplementedError('Polygons with points with geometry dimension'
+                                  f'{GD} has not been implemented.')
+    if not isinstance(axes, Axes):
+        raise TypeError(f"Require 2d Axes object but got {axes.__class__.__name__}.")
+
+    from matplotlib.patches import Polygon
+    from matplotlib.collections import PatchCollection
+    NC = len(struct_seq)
+    patches = [
+        Polygon(points[struct_seq[i], :], closed=True)
+        for i in range(NC)
+    ]
+    poly = PatchCollection(patches=patches)
 
     poly.set_edgecolor(edgecolor)
     poly.set_linewidth(linewidths)

--- a/fealpy/mesh/plotting/classic.py
+++ b/fealpy/mesh/plotting/classic.py
@@ -1,12 +1,12 @@
 
-from typing import Callable, Optional, TypeVar, Any, Union, Sequence, Generic
+from typing import (
+    Callable, Optional, TypeVar, Any, Union, Sequence, Generic,
+    Type
+)
 import numpy as np
 from numpy.typing import NDArray
 from matplotlib.axes import Axes
-from matplotlib import colors, cm
-from mpl_toolkits.mplot3d import Axes3D
 
-from fealpy.mesh.mesh_base import Mesh
 from ..mesh_base import Mesh, Mesh1d, Mesh2d, Mesh3d
 from . import artist as A
 
@@ -14,22 +14,12 @@ _MT = TypeVar('_MT', bound=Mesh)
 
 def array_color_map(arr: NDArray, cmap,
                     cmax: Optional[float]=None, cmin: Optional[float]=None):
+    from matplotlib import colors, cm
+
     cmax = cmax or arr.max()
     cmin = cmin or arr.min()
     norm = colors.Normalize(vmin=cmin, vmax=cmax)
     return cm.ScalarMappable(norm=norm, cmap=cmap)
-
-
-class Plotable():
-    def __init__(self, mesh) -> None:
-        self._mesh = mesh
-
-    @property
-    def add_plot(self):
-        return self._get_ploter()
-
-    def _get_ploter(self):
-        pass
 
 
 class MeshPloter(Generic[_MT]):
@@ -53,7 +43,7 @@ class MeshPloter(Generic[_MT]):
 
     @property
     def mesh(self):
-        return self.mesh
+        return self._mesh
 
     def _call_impl(self, axes: Axes, *args, **kwargs):
         self.current_axes = axes
@@ -72,6 +62,8 @@ class MeshPloter(Generic[_MT]):
 
     def set_box_aspect(self, aspect: Optional[Union[float, Sequence[float]]]=None):
         if aspect is None:
+            from mpl_toolkits.mplot3d import Axes3D
+
             if isinstance(self._axes, Axes3D):
                 self._axes.set_box_aspect((1.0, 1.0, 1.0))
             else:
@@ -80,6 +72,8 @@ class MeshPloter(Generic[_MT]):
             self._axes.set_box_aspect(aspect=aspect)
 
     def set_lim(self, box: Optional[NDArray]=None):
+        from mpl_toolkits.mplot3d import Axes3D
+
         GD = self._mesh.geo_dimension()
         if box is None:
             node: NDArray = self._mesh.entity('node')
@@ -95,18 +89,224 @@ class MeshPloter(Generic[_MT]):
         if isinstance(self._axes, Axes3D):
             self._axes.set_zlim(box[4:6])
 
-    def find_cell(self):
-        pass
+
+class Plotable():
+    """
+    @brief Base class for plotable meshes. Inherit this class to obtain several\
+           plotting methods.
+
+    Before using these plotting methods, call the class method
+    `MeshClass.set_ploter()` to chose a proper ploter for the mesh type.
+    For example, specity a plotter for a mesh type named 'TriangleMesh':
+    ```
+        class TriangleMesh(Mesh2d, Plotable):
+            # codes for mesh ...
+            ...
+
+        TriangleMesh.set_ploter(MyPloter)
+    ```
+    Here `MyPloter` is a subclass of `MeshPloter`. Then, instances of `TriangleMesh`
+    may call methods such as `add_plot()` to draw the mesh.
+
+    @seealso: MeshPloter.
+    """
+    _ploter_class: Optional[Type[MeshPloter]] = None
+
+    @property
+    def add_plot(self):
+        if self._ploter_class is not None:
+            return self._ploter_class(self)
+        else:
+            raise Exception('MeshPloter of the type of mesh should be specified'
+                            'before drawing. If a mesh is inherited from Plotable,'
+                            'use MeshClass.set_ploter(MeshPloterClass) to specify.')
+
+    @classmethod
+    def set_ploter(cls, ploter: Type[MeshPloter]):
+        cls._ploter_class = ploter
+
+    def find_entity(self, axes: Axes, etype: Union[int, str], index=np.s_[:],
+                    showindex: bool=False, color='r', markersize=20,
+                    fontcolor='k', fontsize=24):
+        """
+        @brief Show barycenters of the entity.
+        """
+        if not isinstance(self, Mesh):
+            raise TypeError("Plotable only works for mesh type,"
+                            f"but got {self.__class__.__name__}.")
+
+        bc = self.entity_barycenter(etype=etype, index=index)
+        if bc.ndim == 1:
+            bc = bc[:, None]
+
+        if isinstance(color, np.ndarray) and np.isreal(color[0]):
+            mapper = array_color_map(color, 'rainbow')
+            color = mapper.to_rgba(color)
+
+        A.scatter(axes=axes, points=bc, color=color, markersize=markersize)
+        if showindex:
+            if index == np.s_[:]:
+                index = np.arange(bc.shape[0])
+            elif isinstance(index, np.ndarray):
+                if (index.dtype is np.bool_):
+                    index, = np.nonzero(index)
+            else:
+                raise TypeError("Unknown index format.")
+            A.show_index(axes=axes, location=bc, number=index,
+                         fontcolor=fontcolor, fontsize=fontsize)
+
+    def find_node(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='r', markersize=20,
+            fontsize=16, fontcolor='r',
+            multi_index=None):
+        return self.find_entity(
+                axes, 'node', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_edge(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='g', markersize=22,
+            fontsize=18, fontcolor='g'):
+        return self.find_entity(
+                axes, 'edge', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_face(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='b', markersize=24,
+            fontsize=20, fontcolor='b'):
+        return self.find_entity(
+                axes, 'face', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+    def find_cell(self, axes,
+            index=np.s_[:],
+            showindex=False,
+            color='y', markersize=26,
+            fontsize=22, fontcolor='y'):
+        return self.find_entity(
+                axes, 'cell', index=index,
+                showindex=showindex,
+                color=color,
+                markersize=markersize,
+                fontsize=fontsize,
+                fontcolor=fontcolor)
+
+
+##################################################
+### MeshPloter subclasses
+##################################################
 
 
 class AddPlot1d(MeshPloter[Mesh1d]):
-    def draw(self):
-        pass
+    def draw(
+            self, nodecolor='k', cellcolor='k',
+            markersize=20, linewidths=1,
+            aspect='equal',
+            shownode=True, showaxis=False,
+            box=None, **kwargs
+        ):
+        axes = self.current_axes
+        self.set_box_aspect(aspect)
+        self.set_show_axis(showaxis)
+        self.set_lim(box)
+
+        node: NDArray = self.mesh.entity('node')
+
+        if node.ndim == 1:
+            node = node[:, None]
+
+        if shownode:
+            A.scatter(axes=axes, points=node, color=nodecolor,
+                      markersize=markersize)
+
+        cell = self.mesh.entity('cell')
+
+        return A.line(axes=axes, points=node, struct=cell, color=cellcolor,
+                      linewidths=linewidths)
 
 
-class AddPlot2d(MeshPloter[Mesh2d]):
-    def draw(self):
-        pass
+class AddPlot2dHomo(MeshPloter[Mesh2d]):
+    def draw(
+            self, edgecolor='k', cellcolor=[0.5, 0.9, 0.45],
+            linewidths: float=1.0, alpha: float=1.0,
+            aspect=None,
+            showaxis: bool=False, colorbar: bool=False, colorbarshrink=1.0,
+            cmax=None, cmin=None, cmap='jet', box=None, **kwargs
+        ):
+        """
+        @brief Add a mesh canvas to the given axes. Then the entities of mesh\
+               (i.e. node, cell) can be found and shown in the mesh background.
+        """
+        axes = self.current_axes
+        self.set_box_aspect(aspect)
+        self.set_show_axis(showaxis)
+        self.set_lim(box)
+
+        if isinstance(cellcolor, np.ndarray) and np.isreal(cellcolor[0]):
+            mapper = array_color_map(cellcolor, cmap=cmap, cmax=cmax, cmin=cmin)
+            cellcolor = mapper.to_rgba(cellcolor)
+            if colorbar:
+                f = axes.get_figure()
+                f.colorbar(mapper, shrink=colorbarshrink, ax=self._axes)
+
+        node = self.mesh.entity('node')
+        cell = self.mesh.entity('cell')
+        ccw = getattr(self.mesh.ds, 'ccw', None)
+        if ccw is not None:
+            cell = cell[..., ccw]
+
+        return A.poly(axes=axes, points=node, struct=cell,
+                      edgecolor=edgecolor, cellcolor=cellcolor,
+                      linewidths=linewidths, alpha=alpha)
+
+
+class AddPlot2dPoly(MeshPloter[Mesh2d]):
+    def draw(
+            self, edgecolor='k', cellcolor=[0.5, 0.9, 0.45],
+            linewidths: float=1.0, alpha: float=1.0,
+            aspect=None,
+            showaxis: bool=False, colorbar: bool=False, colorbarshrink=1.0,
+            cmax=None, cmin=None, cmap='jet', box=None, **kwargs
+        ):
+        """
+        @brief Add a mesh canvas to the given axes. Then the entities of mesh\
+               (i.e. node, cell) can be found and shown in the mesh background.
+        """
+        axes = self.current_axes
+        self.set_box_aspect(aspect)
+        self.set_show_axis(showaxis)
+        self.set_lim(box)
+
+        if isinstance(cellcolor, np.ndarray) and np.isreal(cellcolor[0]):
+            mapper = array_color_map(cellcolor, cmap=cmap, cmax=cmax, cmin=cmin)
+            cellcolor = mapper.to_rgba(cellcolor)
+            if colorbar:
+                f = axes.get_figure()
+                f.colorbar(mapper, shrink=colorbarshrink, ax=self._axes)
+
+        node = self.mesh.entity('node')
+        cell = self.mesh.entity('cell') # A list containing indices of vertices.
+
+        return A.poly_(axes=axes, points=node, struct_seq=cell,
+                       edgecolor=edgecolor, cellcolor=cellcolor,
+                      linewidths=linewidths, alpha=alpha)
 
 
 class AddPlot3d(MeshPloter[Mesh3d]):
@@ -126,64 +326,63 @@ class AddPlot3d(MeshPloter[Mesh3d]):
             mapper = array_color_map(nodecolor, cmap='rainbow')
             nodecolor = mapper.to_rgba(nodecolor)
 
-        node: NDArray = self._mesh.entity('node')
+        node = self.mesh.entity('node')
         if shownode:
             A.scatter(axes=axes, points=node, color=nodecolor, markersize=markersize)
 
         if showedge:
-            edge: NDArray = self._mesh.entity('edge')
+            edge = self.mesh.entity('edge')
             A.line(axes=axes, points=node, struct=edge, color=edgecolor,
                    linewidths=linewidths)
 
-        face: NDArray = self._mesh.entity('face')
-        ccw = getattr(self._mesh.ds, 'ccw', None)
+        face = self.mesh.entity('face')
+        ccw = getattr(self.mesh.ds, 'ccw', None)
         if ccw is not None:
             face = face[..., ccw]
-        isBdFace = self._mesh.ds.boundary_face_flag()
+        isBdFace = self.mesh.ds.boundary_face_flag()
 
         if threshold is None:
             face = face[isBdFace]
         else:
-            bc = self._mesh.entity_barycenter('cell')
+            bc = self.mesh.entity_barycenter('cell')
             isKeepCell = threshold(bc)
-            face2cell = self._mesh.ds.face_to_cell()
+            face2cell = self.mesh.ds.face_to_cell()
             isInterfaceFace = np.sum(isKeepCell[face2cell[:, 0:2]], axis=-1) == 1
             isBdFace = (np.sum(isKeepCell[face2cell[:, 0:2]], axis=-1) == 2) and isBdFace
             face = face[isBdFace | isInterfaceFace]
 
-        poly = A.poly(axes=axes, points=node, struct=face, edgecolor=edgecolor,
+        return A.poly(axes=axes, points=node, struct=face, edgecolor=edgecolor,
                       cellcolor=cellcolor, linewidths=linewidths, alpha=alpha)
-        return axes.add_collection(poly)
 
 
-_DEFAULTS = {
-    'nodecolor': 'r',
-    'edgecolor': 'k',
-    'facecolor': 'cy',
-    'cellcolor': [0.2, 0.6, 1.0],
+# _DEFAULTS = {
+#     'nodecolor': 'r',
+#     'edgecolor': 'k',
+#     'facecolor': 'cy',
+#     'cellcolor': [0.2, 0.6, 1.0],
 
-    'markersize': 10.0,
-    'linewidths': 0.1,
-    'alpha': 1.0,
-}
+#     'markersize': 10.0,
+#     'linewidths': 0.1,
+#     'alpha': 1.0,
+# }
 
 
-class PlotModule():
-    def __init__(self, **kwargs) -> None:
-        self._options = kwargs
+# class PlotModule():
+#     def __init__(self, **kwargs) -> None:
+#         self._options = kwargs
 
-    def _get_options(self, key: str):
-        if key in self._options:
-            return self._options[key]
-        elif key in _DEFAULTS:
-            return _DEFAULTS[key]
-        else:
-            raise KeyError(f"Failed to load default value of {key}.")
+#     def _get_options(self, key: str):
+#         if key in self._options:
+#             return self._options[key]
+#         elif key in _DEFAULTS:
+#             return _DEFAULTS[key]
+#         else:
+#             raise KeyError(f"Failed to load default value of {key}.")
 
-    def _call_impl(self, axes: Axes, mesh: Mesh):
-        return self.draw(axes=axes, mesh=mesh)
+#     def _call_impl(self, axes: Axes, mesh: Mesh):
+#         return self.draw(axes=axes, mesh=mesh)
 
-    __call__ = _call_impl
+#     __call__ = _call_impl
 
-    def draw(self, axes: Axes, mesh: Mesh):
-        raise NotImplementedError
+#     def draw(self, axes: Axes, mesh: Mesh):
+#         raise NotImplementedError

--- a/fealpy/mesh/plotting/classic.py
+++ b/fealpy/mesh/plotting/classic.py
@@ -1,0 +1,189 @@
+
+from typing import Callable, Optional, TypeVar, Any, Union, Sequence, Generic
+import numpy as np
+from numpy.typing import NDArray
+from matplotlib.axes import Axes
+from matplotlib import colors, cm
+from mpl_toolkits.mplot3d import Axes3D
+
+from fealpy.mesh.mesh_base import Mesh
+from ..mesh_base import Mesh, Mesh1d, Mesh2d, Mesh3d
+from . import artist as A
+
+_MT = TypeVar('_MT', bound=Mesh)
+
+def array_color_map(arr: NDArray, cmap,
+                    cmax: Optional[float]=None, cmin: Optional[float]=None):
+    cmax = cmax or arr.max()
+    cmin = cmin or arr.min()
+    norm = colors.Normalize(vmin=cmin, vmax=cmax)
+    return cm.ScalarMappable(norm=norm, cmap=cmap)
+
+
+class Plotable():
+    def __init__(self, mesh) -> None:
+        self._mesh = mesh
+
+    @property
+    def add_plot(self):
+        return self._get_ploter()
+
+    def _get_ploter(self):
+        pass
+
+
+class MeshPloter(Generic[_MT]):
+    _axes: Axes
+    _mesh: _MT
+
+    def __init__(self, mesh: _MT) -> None:
+        self._mesh = mesh
+
+    @property
+    def current_axes(self):
+        return self._axes
+
+    @current_axes.setter
+    def current_axes(self, axes: Axes):
+        if isinstance(axes, Axes):
+            self._axes = axes
+        else:
+            raise TypeError("Param 'axes' should be Axes type"
+                            f"but got {axes.__class__.__name__}.")
+
+    @property
+    def mesh(self):
+        return self.mesh
+
+    def _call_impl(self, axes: Axes, *args, **kwargs):
+        self.current_axes = axes
+
+        return self.draw(*args, **kwargs)
+
+    __call__ = _call_impl
+
+    draw: Callable[..., Any]
+
+    def set_show_axis(self, switch: bool=True):
+        if switch:
+            self._axes.set_axis_on()
+        else:
+            self._axes.set_axis_off()
+
+    def set_box_aspect(self, aspect: Optional[Union[float, Sequence[float]]]=None):
+        if aspect is None:
+            if isinstance(self._axes, Axes3D):
+                self._axes.set_box_aspect((1.0, 1.0, 1.0))
+            else:
+                self._axes.set_box_aspect(1.0)
+        else:
+            self._axes.set_box_aspect(aspect=aspect)
+
+    def set_lim(self, box: Optional[NDArray]=None):
+        GD = self._mesh.geo_dimension()
+        if box is None:
+            node: NDArray = self._mesh.entity('node')
+            em: NDArray = self._mesh.entity_measure('edge')
+            tol = np.max(em)/100
+            box = np.zeros(2*GD, dtype=np.float64)
+            box[0::2] = np.min(node, axis=0) - tol
+            box[1::2] = np.max(node, axis=0) + tol
+
+        self._axes.set_xlim(box[0:2])
+        self._axes.set_ylim(box[2:4])
+
+        if isinstance(self._axes, Axes3D):
+            self._axes.set_zlim(box[4:6])
+
+    def find_cell(self):
+        pass
+
+
+class AddPlot1d(MeshPloter[Mesh1d]):
+    def draw(self):
+        pass
+
+
+class AddPlot2d(MeshPloter[Mesh2d]):
+    def draw(self):
+        pass
+
+
+class AddPlot3d(MeshPloter[Mesh3d]):
+    def draw(
+            self, nodecolor='k', edgecolor='k', cellcolor='w',
+            markersize=20, linewidths=0.5, alpha=0.8,
+            aspect: Optional[Union[float, Sequence[float]]]=None,
+            showaxis=False, shownode=False, showedge=False, threshold=None,
+            box=None, **kwargs
+        ):
+        axes = self.current_axes
+        self.set_box_aspect(aspect)
+        self.set_show_axis(showaxis)
+        self.set_lim(box)
+
+        if isinstance(nodecolor, np.ndarray) and np.isreal(nodecolor[0]):
+            mapper = array_color_map(nodecolor, cmap='rainbow')
+            nodecolor = mapper.to_rgba(nodecolor)
+
+        node: NDArray = self._mesh.entity('node')
+        if shownode:
+            A.scatter(axes=axes, points=node, color=nodecolor, markersize=markersize)
+
+        if showedge:
+            edge: NDArray = self._mesh.entity('edge')
+            A.line(axes=axes, points=node, struct=edge, color=edgecolor,
+                   linewidths=linewidths)
+
+        face: NDArray = self._mesh.entity('face')
+        ccw = getattr(self._mesh.ds, 'ccw', None)
+        if ccw is not None:
+            face = face[..., ccw]
+        isBdFace = self._mesh.ds.boundary_face_flag()
+
+        if threshold is None:
+            face = face[isBdFace]
+        else:
+            bc = self._mesh.entity_barycenter('cell')
+            isKeepCell = threshold(bc)
+            face2cell = self._mesh.ds.face_to_cell()
+            isInterfaceFace = np.sum(isKeepCell[face2cell[:, 0:2]], axis=-1) == 1
+            isBdFace = (np.sum(isKeepCell[face2cell[:, 0:2]], axis=-1) == 2) and isBdFace
+            face = face[isBdFace | isInterfaceFace]
+
+        poly = A.poly(axes=axes, points=node, struct=face, edgecolor=edgecolor,
+                      cellcolor=cellcolor, linewidths=linewidths, alpha=alpha)
+        return axes.add_collection(poly)
+
+
+_DEFAULTS = {
+    'nodecolor': 'r',
+    'edgecolor': 'k',
+    'facecolor': 'cy',
+    'cellcolor': [0.2, 0.6, 1.0],
+
+    'markersize': 10.0,
+    'linewidths': 0.1,
+    'alpha': 1.0,
+}
+
+
+class PlotModule():
+    def __init__(self, **kwargs) -> None:
+        self._options = kwargs
+
+    def _get_options(self, key: str):
+        if key in self._options:
+            return self._options[key]
+        elif key in _DEFAULTS:
+            return _DEFAULTS[key]
+        else:
+            raise KeyError(f"Failed to load default value of {key}.")
+
+    def _call_impl(self, axes: Axes, mesh: Mesh):
+        return self.draw(axes=axes, mesh=mesh)
+
+    __call__ = _call_impl
+
+    def draw(self, axes: Axes, mesh: Mesh):
+        raise NotImplementedError

--- a/fealpy/mesh/polygon_mesh.py
+++ b/fealpy/mesh/polygon_mesh.py
@@ -7,9 +7,8 @@ from ..common import ranges
 from ..quadrature import TriangleQuadrature
 from ..quadrature import GaussLegendreQuadrature
 
-from .mesh_base import Mesh2d
+from .mesh_base import Mesh2d, Plotable
 from .mesh_data_structure import Mesh2dDataStructure
-from .plotting import Plotable, AddPlot2dPoly
 
 
 class PolygonMesh(Mesh2d, Plotable):
@@ -132,7 +131,7 @@ class PolygonMesh(Mesh2d, Plotable):
         return cls(node, cell, cellLocation)
 
 
-PolygonMesh.set_ploter(AddPlot2dPoly)
+PolygonMesh.set_ploter('polygon2d')
 
 
 class PolygonMeshDataStructure(Mesh2dDataStructure):

--- a/fealpy/mesh/polygon_mesh.py
+++ b/fealpy/mesh/polygon_mesh.py
@@ -9,8 +9,10 @@ from ..quadrature import GaussLegendreQuadrature
 
 from .mesh_base import Mesh2d
 from .mesh_data_structure import Mesh2dDataStructure
+from .plotting import Plotable, AddPlot2dPoly
 
-class PolygonMesh(Mesh2d):
+
+class PolygonMesh(Mesh2d, Plotable):
     """
     @brief Polygon mesh type.
     """
@@ -19,7 +21,7 @@ class PolygonMesh(Mesh2d):
     def __init__(self, node: NDArray, cell: NDArray, cellLocation=None, topdata=None):
         self.node = node
         if cellLocation is None:
-            if len(cell.shape)  == 2:
+            if len(cell.shape) == 2:
                 NC = cell.shape[0]
                 NV = cell.shape[1]
                 cell = cell.reshape(-1)
@@ -57,7 +59,7 @@ class PolygonMesh(Mesh2d):
             cell2node = self.ds.cell_to_node()
             NV = self.ds.number_of_vertices_of_cells().reshape(-1, 1)
             bc = cell2node*node/NV
-        elif etype in {'edge', 1}:
+        elif etype in {'edge', 'face', 1}:
             edge = self.ds.edge
             bc = np.mean(node[edge, :], axis=1).reshape(-1, GD)
         elif etype in {'node', 0}:
@@ -130,6 +132,9 @@ class PolygonMesh(Mesh2d):
         return cls(node, cell, cellLocation)
 
 
+PolygonMesh.set_ploter(AddPlot2dPoly)
+
+
 class PolygonMeshDataStructure(Mesh2dDataStructure):
     TD: int = 2
     def __init__(self, NN: int, cell: NDArray, cellLocation: NDArray, topdata=None):
@@ -184,7 +189,8 @@ class PolygonMeshDataStructure(Mesh2dDataStructure):
         self.edge = totalEdge[i0]
 
         NV = self.number_of_vertices_of_cells()
-        cellIdx = np.repeat(range(self.NC), NV)
+        NC = self.number_of_cells()
+        cellIdx = np.repeat(range(NC), NV)
 
         localIdx = ranges(NV)
 
@@ -205,7 +211,7 @@ class PolygonMeshDataStructure(Mesh2dDataStructure):
 
         NV = self.number_of_vertices_of_cells()
         I = np.repeat(range(NC), NV)
-        J = self.cell
+        J = self._cell
 
         val = np.ones(len(self._cell), dtype=np.bool_)
         cell2node = csr_matrix((val, (I, J)), shape=(NC, NN), dtype=np.bool_)


### PR DESCRIPTION
(NEW) mesh/plotting/
- Implements common used plot tools in artist.py. This file is to provide all basic functions that draw points, lines and polygons on the axes.
- Defines a base class `MeshPloter` in classic.py. All plotting methods for meshes should be implemented as subclasses of `MeshPloter`. Each class represents a special **drawing plan**.
- To define a ploter class, inherit from `MeshPloter` and then override `draw` method, which is supposed to finish the plotting (things that happens in `mesh.add_plot()`.

(NEW) mesh/mesh_base/plot.py
- A base class `Plotable` from which a mesh class can get some plotting methods by inheriting.
- After finish a ploter class, for example, named `MyPloter`, use `MyPloter.register('myploter')`. Then every `Plotable` mesh may use `MeshType.set_ploter('myploter')` to specify the drawing plan for the mesh.

(UPDATE) mesh/polygon_mesh.py
- Make the new polygon mesh plotable, by
```python
def PolygonMesh(Mesh2d, Plotable):
    ... # codes for polygon mesh

PolygonMesh.set_ploter('polygon2d')
```
Now polygon mesh instances can call plotting methods such as `add_plot`, `find_cell`, ...