### PR TITLE
mesh: update interval mesh

### DIFF
--- a/fealpy/mesh/interval_mesh.py
+++ b/fealpy/mesh/interval_mesh.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.typing import NDArray
 from scipy.sparse import csr_matrix
 from types import ModuleType
 
@@ -7,25 +8,13 @@ from .mesh_base import Mesh1d, Plotable
 from .mesh_data_structure import Mesh1dDataStructure
 
 class IntervalMeshDataStructure(Mesh1dDataStructure):
-    def __init__(self, NN, cell):
-        self.NN = NN
-        self.NC = len(cell)
-        self.cell = cell
-        self.itype = cell.dtype
-        self.construct()
-
-    def reinit(self, NN, cell):
-        self.NN = NN
-        self.NC = cell.shape[0]
-        self.cell = cell
-        self.construct()
 
     def total_face(self):
         return self.cell.reshape(-1, 1)
 
 
 class IntervalMesh(Mesh1d, Plotable):
-    def __init__(self, node, cell):
+    def __init__(self, node: NDArray, cell: NDArray):
         if node.ndim == 1:
             self.node = node.reshape(-1, 1)
         else:
@@ -37,7 +26,7 @@ class IntervalMesh(Mesh1d, Plotable):
         self.nodedata = {}
         self.celldata = {}
         self.edgedata = self.celldata # celldata and edgedata are the same thing
-        self.facedata = self.nodedata # facedata and nodedata are the same thing 
+        self.facedata = self.nodedata # facedata and nodedata are the same thing
 
         self.itype = cell.dtype
         self.ftype = node.dtype
@@ -71,10 +60,10 @@ class IntervalMesh(Mesh1d, Plotable):
         cell = np.c_[np.zeros((NC, 1), dtype=cell.dtype), cell]
         cell[:, 0] = NV
 
-        cellType = self.vtk_cell_type()  # segment 
+        cellType = self.vtk_cell_type()  # segment
 
         if fname is None:
-            return node, cell.flatten(), cellType, NC 
+            return node, cell.flatten(), cellType, NC
         else:
             print("Writting to vtk...")
             write_to_vtu(fname, node, NC, cellType, cell.flatten(),
@@ -132,7 +121,7 @@ class IntervalMesh(Mesh1d, Plotable):
             inplace 默认为 True， 意思是直接在单元内部修改
 
         TODO:
-            1. 实现 inplace 为 False 的情形 
+            1. 实现 inplace 为 False 的情形
         """
         for i in range(n):
             NN = self.number_of_nodes()
@@ -215,12 +204,12 @@ class IntervalMesh(Mesh1d, Plotable):
         dt = 2*np.pi/n
         theta  = np.arange(0, 2*np.pi, dt)
 
-        node = np.zeros((n, 2),dtype = np.float64)
-        cell = np.zeros((n, 2),dtype = np.int_)
+        node = np.zeros((n, 2), dtype=np.float64)
+        cell = np.zeros((n, 2), dtype=np.int_)
 
 
-        node[:, 0] = r*np.cos(theta)
-        node[:, 1] = r*np.sin(theta)
+        node[:, 0] = radius*np.cos(theta)
+        node[:, 1] = radius*np.sin(theta)
 
         node[:, 0] = node[:,0] + center[0]
         node[:, 1] = node[:,1] + center[1]
@@ -230,6 +219,4 @@ class IntervalMesh(Mesh1d, Plotable):
 
         return cls(node, cell)
 
-IntervalMesh.set_ploter('intervalmesh')
-
-
+IntervalMesh.set_ploter('1d')

--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -20,11 +20,6 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     localEdge = np.array([(0, 1)], dtype=np.int_)
     localFace = np.array([(0, ), (1, )], dtype=np.int_)
 
-    @property
-    def face(self):
-        NN = self.number_of_nodes()
-        return np.arange(NN, dtype=self.itype).reshape(NN, 1)
-
     ### cell ###
 
     def cell_to_edge(self) -> NDArray:
@@ -35,6 +30,24 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
         return self.cell
 
     ### face ###
+
+    def face_to_cell(self) -> NDArray:
+        return self.face2cell
+
+    face_to_edge = face_to_cell
+
+    ### edge ###
+
+    edge_to_face = cell_to_face
+    edge_to_cell = cell_to_edge
+
+    ### node ###
+
+    node_to_edge = face_to_cell
+    node_to_cell = face_to_cell
+
+
+class StructureMesh1dDataStructure(StructureMeshDS, Mesh1dDataStructure):
 
     def face_to_cell(self) -> NDArray:
         """
@@ -52,19 +65,3 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
         node2cell[-1, 1] = NC - 1
         node2cell[-1, 3] = 1
         return node2cell
-
-    face_to_edge = face_to_cell
-
-    ### edge ###
-
-    edge_to_face = cell_to_face
-    edge_to_cell = cell_to_edge
-
-    ### node ###
-
-    node_to_edge = face_to_cell
-    node_to_cell = face_to_cell
-
-
-class StructureMesh1dDataStructure(StructureMeshDS, Mesh1dDataStructure):
-    pass

--- a/fealpy/mesh/mesh_data_structure/mesh_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh_ds.py
@@ -272,7 +272,7 @@ class HomogeneousMeshDS(MeshDataStructure):
         self.face2cell = np.zeros((NF, 4), dtype=self.itype)
 
         i1 = np.zeros(NF, dtype=self.itype)
-        i1[j] = np.arange(NF, dtype=self.itype)
+        i1[j] = np.arange(NFC*NC, dtype=self.itype)
 
         self.face2cell[:, 0] = i0 // NFC
         self.face2cell[:, 1] = i1 // NFC

--- a/fealpy/mesh/plotting/classic.py
+++ b/fealpy/mesh/plotting/classic.py
@@ -94,17 +94,19 @@ class MeshPloter(Generic[_MT]):
         else:
             self._axes.set_box_aspect(aspect=aspect)
 
-    def set_lim(self, box: Optional[NDArray]=None):
+    def set_lim(self, box: Optional[NDArray]=None, tol=0.1):
         from mpl_toolkits.mplot3d import Axes3D
 
         GD = self._mesh.geo_dimension()
+
         if box is None:
             node: NDArray = self._mesh.entity('node')
-            em: NDArray = self._mesh.entity_measure('edge')
-            tol = np.max(em)/100
-            box = np.zeros(2*GD, dtype=np.float64)
-            box[0::2] = np.min(node, axis=0) - tol
-            box[1::2] = np.max(node, axis=0) + tol
+            if node.ndim == 1:
+                node = node.reshape(-1, 1)
+
+            box = np.array([-0.5, 0.5]*3, dtype=np.float64)
+            box[0:2*GD:2] = np.min(node, axis=0) - tol
+            box[1:1+2*GD:2] = np.max(node, axis=0) + tol
 
         self._axes.set_xlim(box[0:2])
         self._axes.set_ylim(box[2:4])
@@ -122,7 +124,7 @@ class AddPlot1d(MeshPloter[Mesh1d]):
     def draw(
             self, nodecolor='k', cellcolor='k',
             markersize=20, linewidths=1,
-            aspect='equal',
+            aspect=None,
             shownode=True, showaxis=False,
             box=None, **kwargs
         ):

--- a/test/mesh/test_interval_mesh.py
+++ b/test/mesh/test_interval_mesh.py
@@ -4,19 +4,51 @@ import pytest
 
 from fealpy.mesh.interval_mesh import IntervalMesh
 
-import ipdb
+# import ipdb
 
 def test_interval_domain():
-    ipdb.set_trace()
+    # ipdb.set_trace()
     mesh = IntervalMesh.from_interval_domain([0, 1], nx=10)
-    fig, axes = plt.subplots()
-    mesh.add_plot(axes)
+    fig = plt.figure("Interval Mesh Test")
+    axes = fig.add_subplot(111)
+    mesh.add_plot(axes, showaxis=True)
     mesh.find_node(axes, showindex=True)
-    mesh.find_cell(axes, showindex=True) 
+    mesh.find_cell(axes, showindex=True)
     plt.show()
 
+
+def test_circle_boundary():
+    mesh = IntervalMesh.from_circle_boundary([0, 0], radius=1.45, n=20)
+    fig = plt.figure("Interval Mesh Test")
+    axes = fig.add_subplot(111)
+    mesh.add_plot(axes, showaxis=True)
+    mesh.find_node(axes, showindex=True)
+    mesh.find_cell(axes, showindex=True)
+    plt.show()
+
+
+class TestDataStructure():
+    def test_topology(self):
+        mesh = IntervalMesh.from_interval_domain([0, 1], nx=17)
+        ds = mesh.ds
+        assert mesh.node.shape == (18, 1)
+        assert ds.edge.shape == (17, 2)
+        assert ds.face.shape == (18, 1)
+        assert ds.cell is mesh.ds.edge
+
+        assert ds.face2cell.shape == (18, 4)
+
+    def test_topology_2(self):
+        mesh = IntervalMesh.from_circle_boundary([0, 0], radius=1.45, n=15)
+        ds = mesh.ds
+        assert mesh.node.shape == (15, 2)
+        assert ds.edge.shape == (15, 2)
+        assert ds.face.shape == (15, 1)
+        assert ds.cell is mesh.ds.edge
+
+        assert ds.face2cell.shape == (15, 4)
 
 
 if __name__ == '__main__':
     test_interval_domain()
-
+    test_circle_boundary()


### PR DESCRIPTION
(Update)mesh/interval_mesh.py
- deleted `__init__()` and `reinit()` as they were already defined in superclass;
- found undefined param `r` in method `from_circle_boundary()`, may be `radius`;
- use the `"1d"` ploter.

(Update)mesh/mesh_data_structure/mesh1d_ds.py
- deleted property `face`, as it was generated in `construct()`;
- move `face_to_cell()` to `StructureMesh1dDatastructure` class;
- new `face_to_cell()` will return `face2cell` directly.

(Update)mesh/mesh_data_structure/mesh_ds.py
- fixed a bug in `construct()`.

(Update)mesh/plotting/classic.py
- fixed a bug in `set_lim`, now the box can fully adapt different geometry dimensions;
- use `1.0` as the default value (of the parameter `aspect` in method `AddPlot1d.draw()`), instead of `"equal"` which is incorrect.

(Update)..test/mesh/test_interval_mesh.py
- added some new tests.