### PR TITLE
update mesh data structure base

### DIFF
--- a/fealpy/mesh/interval_mesh.py
+++ b/fealpy/mesh/interval_mesh.py
@@ -5,12 +5,13 @@ from typing import Union
 from types import ModuleType
 
 from .mesh_base import Mesh, Plotable
-from .mesh_data_structure import Mesh1dDataStructure, HomogeneousMeshDS
+from .mesh_data_structure import Mesh1dDataStructure
 
 
-class IntervalMeshDataStructure(Mesh1dDataStructure, HomogeneousMeshDS):
+class IntervalMeshDataStructure(Mesh1dDataStructure):
     def total_face(self):
         return self.cell.reshape(-1, 1)
+
 
 class IntervalMesh(Mesh, Plotable):
     def __init__(self, node: NDArray, cell: NDArray):
@@ -53,13 +54,13 @@ class IntervalMesh(Mesh, Plotable):
 
     def grad_shape_function(self, bc: NDArray, p: int=1, variables: str='x', index=np.s_[:]):
         """
-        @brief 
+        @brief
         """
         R = self._grad_shape_function(bc, p=p)
         if variables == 'x':
             Dlambda = self.grad_lambda(index=index)
             gphi = np.einsum('...ij, cjm->...cim', R, Dlambda)
-            return gphi 
+            return gphi
         else:
             return R
 
@@ -80,7 +81,7 @@ class IntervalMesh(Mesh, Plotable):
         node = self.entity('node')
         cell = self.entity('cell', index=index)
         v = node[cell[:, 1]] - node[cell[:, 0]]
-        NC = len(cell) 
+        NC = len(cell)
         GD = self.geo_dimension()
         Dlambda = np.zeros((NC, 2, GD), dtype=self.ftype)
         h2 = np.sum(v**2, axis=-1)
@@ -136,7 +137,7 @@ class IntervalMesh(Mesh, Plotable):
 
     def uniform_refine(self, n=1, options={}):
         """
-        @brief 一致加密网格 
+        @brief 一致加密网格
         """
         for i in range(n):
             NN = self.number_of_nodes()

--- a/fealpy/mesh/mesh_base/mesh.py
+++ b/fealpy/mesh/mesh_base/mesh.py
@@ -7,7 +7,7 @@ from ..mesh_data_structure import MeshDataStructure
 
 class Mesh():
     """
-    @brief The base class for mesh. 
+    @brief The base class for mesh.
 
     """
     ds: MeshDataStructure
@@ -31,15 +31,15 @@ class Mesh():
 
     def number_of_nodes_of_cells(self) -> int:
         """Number of nodes in a cell"""
-        return self.ds.NVC
+        return self.ds.number_of_vertices_of_cells()
 
     def number_of_edges_of_cells(self) -> int:
         """Number of edges in a cell"""
-        return self.ds.NEC
+        return self.ds.number_of_edges_of_cells()
 
     def number_of_faces_of_cells(self) -> int:
         """Number of faces in a cell"""
-        return self.ds.NFC
+        return self.ds.number_of_faces_of_cells()
 
     number_of_vertices_of_cells = number_of_nodes_of_cells
 
@@ -60,7 +60,7 @@ class Mesh():
         """
         @brief 获取 p 次的多重指标矩阵
 
-        @param[in] p 正整数 
+        @param[in] p 正整数
 
         @return multiIndex  ndarray with shape (ldof, TD+1)
         """
@@ -95,7 +95,7 @@ class Mesh():
 
     def _shape_function(self, bc, p=1):
         """
-        @brief    
+        @brief
         """
         if p == 1:
             return bc
@@ -118,7 +118,7 @@ class Mesh():
         @brief 计算形状为 (..., TD+1) 的重心坐标数组 bc 中, 每一个重心坐标处的 p 次 Lagrange 形函数值关于该重心坐标的梯度。
         """
         TD = bc.shape[-1] - 1
-        multiIndex = self.multi_index_matrix(p, etype=TD) 
+        multiIndex = self.multi_index_matrix(p, etype=TD)
         ldof = multiIndex.shape[0] # p 次 Lagrange 形函数的个数
 
         c = np.arange(1, p+1)
@@ -152,13 +152,13 @@ class Mesh():
 
     def shape_function(self, bc, p=1) -> NDArray:
         """
-        @brief The cell shape function. 
+        @brief The cell shape function.
         """
         raise NotImplementedError
 
     def grad_shape_function(self, bc, p=1, variables='x', index=np.s_[:]):
         """
-        @brief The gradient of the cell shape function. 
+        @brief The gradient of the cell shape function.
         """
         raise NotImplementedError
 
@@ -290,7 +290,7 @@ class Mesh():
         edge2ipoints[:, [0, -1]] = edge
         if p > 1:
             idx = NN + np.arange(p-1)
-            edge2ipoints[:, 1:-1] =  (p-1)*index[:, None] + idx 
+            edge2ipoints[:, 1:-1] =  (p-1)*index[:, None] + idx
         return edge2ipoints
 
     def edge_length(self, index=np.s_[:], node=None):

--- a/fealpy/mesh/mesh_data_structure/__init__.py
+++ b/fealpy/mesh/mesh_data_structure/__init__.py
@@ -2,7 +2,10 @@
 Provide ABCs for topology data class of mesh
 """
 
-from .mesh_ds import MeshDataStructure, HomogeneousMeshDS, StructureMeshDS
+from .mesh_ds import (
+    MeshDataStructure, HomogeneousMeshDS, StructureMeshDS,
+    ArrRedirector
+)
 from .mesh1d_ds import Mesh1dDataStructure, StructureMesh1dDataStructure
 from .mesh2d_ds import Mesh2dDataStructure, StructureMesh2dDataStructure
 from .mesh3d_ds import Mesh3dDataStructure, StructureMesh3dDataStructure

--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -4,7 +4,7 @@ from numpy.typing import NDArray
 from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
-from .mesh_ds import Redirector, HomogeneousMeshDS, StructureMeshDS
+from .mesh_ds import ArrRedirector, HomogeneousMeshDS, StructureMeshDS
 
 
 class Mesh1dDataStructure(HomogeneousMeshDS):
@@ -13,7 +13,7 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
            This is an abstract class and can not be used directly.
     """
     # Variables
-    edge: Redirector[NDArray] = Redirector('cell')
+    edge = ArrRedirector('cell')
 
     # Constants
     TD = 1
@@ -21,6 +21,9 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     localFace = np.array([(0, ), (1, )], dtype=np.int_)
 
     ### cell ###
+
+    def cell_to_node(self) -> NDArray:
+        return self.cell
 
     def cell_to_edge(self) -> NDArray:
         NC = self.number_of_cells()

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -4,22 +4,25 @@ from numpy.typing import NDArray
 from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
-from .mesh_ds import Redirector, MeshDataStructure, StructureMeshDS
+from .mesh_ds import ArrRedirector, HomogeneousMeshDS, StructureMeshDS
 
 
-class Mesh2dDataStructure(MeshDataStructure):
+class Mesh2dDataStructure(HomogeneousMeshDS):
     """
-    @brief The topology data structure of 2-d mesh.\
+    @brief The topology data structure of 2-d homogeneous mesh.\
            This is an abstract class and can not be used directly.
     """
     # Variables
-    face: Redirector[NDArray] = Redirector('edge')
+    face = ArrRedirector('edge')
     edge2cell: NDArray
 
     # Constants
     TD: int = 2
 
     ### cell ###
+
+    def cell_to_node(self) -> NDArray:
+        return self.cell
 
     def cell_to_edge(self):
         """
@@ -61,8 +64,8 @@ class Mesh2dDataStructure(MeshDataStructure):
         NE = self.number_of_edges()
 
         edge2cell = self.edge2cell
-        if (return_sparse == False) & (return_array == False):
-            NEC = self.NEC
+        if (return_sparse == False) and (return_array == False):
+            NEC = self.number_of_edges_of_cells()
             cell2cell = np.zeros((NC, NEC), dtype=self.itype)
             cell2cell[edge2cell[:, 0], edge2cell[:, 2]] = edge2cell[:, 1]
             cell2cell[edge2cell[:, 1], edge2cell[:, 3]] = edge2cell[:, 0]

--- a/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
@@ -4,12 +4,12 @@ from numpy.typing import NDArray
 from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
-from .mesh_ds import MeshDataStructure, StructureMeshDS
+from .mesh_ds import HomogeneousMeshDS, StructureMeshDS
 
 
-class Mesh3dDataStructure(MeshDataStructure):
+class Mesh3dDataStructure(HomogeneousMeshDS):
     """
-    @brief The topology data structure of 3-d mesh.\
+    @brief The topology data structure of 3-d homogeneous mesh.\
            This is an abstract class and can not be used directly.
     """
     # Variables
@@ -18,6 +18,16 @@ class Mesh3dDataStructure(MeshDataStructure):
 
     # Constants
     TD: int = 3
+    localFace2edge: NDArray
+    localEdge2face: NDArray
+
+    def number_of_edges_of_faces(self):
+        """
+        @brief Return the number of edges in a face, and is only available in 3d mesh.
+
+        This is equal to the length of `localFace2edge` in axis-1.
+        """
+        return self.localFace2edge.shape[1]
 
     ### Cell ###
 

--- a/fealpy/mesh/triangle_mesh.py
+++ b/fealpy/mesh/triangle_mesh.py
@@ -6,19 +6,12 @@ from scipy.spatial import KDTree
 from .triangle_quality import *
 
 from .mesh_base import Mesh, Plotable
-from .mesh_data_structure import Mesh2dDataStructure, HomogeneousMeshDS
+from .mesh_data_structure import Mesh2dDataStructure
 
-class TriangleMeshDataStructure(Mesh2dDataStructure, HomogeneousMeshDS):
+class TriangleMeshDataStructure(Mesh2dDataStructure):
     localEdge = np.array([(1, 2), (2, 0), (0, 1)])
     localFace = np.array([(1, 2), (2, 0), (0, 1)])
     ccw = np.array([0, 1, 2])
-
-    NVC: int = 3
-    NVE: int = 2
-    NVF: int = 2
-
-    NEC: int = 3
-    NFC: int = 3
 
     localCell = np.array([
         (0, 1, 2),
@@ -52,7 +45,7 @@ class TriangleMesh(Mesh, Plotable):
         self.edgedata = {}
         self.facedata = self.edgedata
         self.meshdata = {}
-        
+
         self.edge_bc_to_point = self.bc_to_point
         self.cell_bc_to_point = self.bc_to_point
         self.face_to_ipoint = self.edge_to_ipoint
@@ -111,7 +104,7 @@ class TriangleMesh(Mesh, Plotable):
         @param bc 边上的一组积分点
         @param cindex 边所在的单元编号
         @param lidx 边在该单元的局部编号
-        @param direction  True 表示边的方向和单元的逆时针方向一致，False 表示不一致 
+        @param direction  True 表示边的方向和单元的逆时针方向一致，False 表示不一致
         """
 
         NC = len(cindex)
@@ -129,7 +122,7 @@ class TriangleMesh(Mesh, Plotable):
 
         gphi = self.grad_shape_function(bcs, p=p, index=cindex, variables='x')
 
-        return gphi 
+        return gphi
 
     grad_shape_function_on_face = grad_shape_function_on_edge
 
@@ -189,7 +182,7 @@ class TriangleMesh(Mesh, Plotable):
         """
         cell = self.entity('cell')
         if p==1:
-            return cell[index] 
+            return cell[index]
 
         mi = self.multi_index_matrix(p, 2)
         idx0, = np.nonzero(mi[:, 0] == 0)
@@ -199,7 +192,7 @@ class TriangleMesh(Mesh, Plotable):
         edge2cell = self.ds.edge_to_cell()
         NN = self.number_of_nodes()
         NE = self.number_of_edges()
-        NC = self.number_of_cells() 
+        NC = self.number_of_cells()
 
         e2p = self.edge_to_ipoint(p)
         ldof = self.number_of_local_ipoints(p)
@@ -234,7 +227,7 @@ class TriangleMesh(Mesh, Plotable):
 
     def edge_frame(self, index=np.s_[:]):
         """
-        @brief 计算二维网格中每条边上的局部标架 
+        @brief 计算二维网格中每条边上的局部标架
         """
         assert self.geo_dimension() == 2
         t = self.edge_unit_tangent(index=index)
@@ -599,7 +592,7 @@ class TriangleMesh(Mesh, Plotable):
         @brief 显示网格角度的分布直方图
         """
         if angle is None:
-            angle = self.angle() 
+            angle = self.angle()
         hist, bins = np.histogram(angle.flatten('F')*180/np.pi, bins=50, range=(0, 180))
         center = (bins[:-1] + bins[1:])/2
         axes.bar(center, hist, align='center', width=180/50.0)
@@ -617,17 +610,17 @@ class TriangleMesh(Mesh, Plotable):
                 textcoords='axes fraction',
                 horizontalalignment='left', verticalalignment='top')
         return mina, maxa, meana
-    
+
     def cell_quality(self,measure='radius_ratio'):
         if measure=='radius_ratio':
-            return radius_ratio(self) 
+            return radius_ratio(self)
 
     def show_quality(self, axes, qtype=None, quality=None):
         """
         @brief 显示网格质量分布的分布直方图
         """
         if quality is None:
-            quality = self.cell_quality() 
+            quality = self.cell_quality()
         minq = np.min(quality)
         maxq = np.max(quality)
         meanq = np.mean(quality)
@@ -695,7 +688,7 @@ class TriangleMesh(Mesh, Plotable):
 
         NN = self.number_of_nodes()
         NC = self.number_of_cells()
-        
+
         isBdNode = self.ds.boundary_node_flag()
         isBdCell = self.ds.boundary_cell_flag()
         isFreeNode = ~isBdNode
@@ -708,10 +701,10 @@ class TriangleMesh(Mesh, Plotable):
 
         newNode = np.zeros((NN,2),dtype=np.float64)
         patch_area = np.zeros(NN,dtype=np.float64)
-        
+
         np.add.at(newNode,cell,np.broadcast_to(cc[:,None],(NC,3,2)))
-        np.add.at(patch_area,cell,np.broadcast_to(cm[:,None],(NC,3))) 
-        
+        np.add.at(patch_area,cell,np.broadcast_to(cm[:,None],(NC,3)))
+
         newNode[isBdNode] = node[isBdNode]
         newNode[isFreeNode] = newNode[isFreeNode]/patch_area[...,None][isFreeNode]
         self.node = newNode
@@ -726,7 +719,7 @@ class TriangleMesh(Mesh, Plotable):
 
         NN = self.number_of_nodes()
         NC = self.number_of_cells()
-        
+
         isBdNode = self.ds.boundary_node_flag()
         isBdCell = self.ds.boundary_cell_flag()
         isFreeNode = ~isBdNode
@@ -737,10 +730,10 @@ class TriangleMesh(Mesh, Plotable):
 
         newNode = np.zeros((NN,2),dtype=np.float64)
         patch_area = np.zeros(NN,dtype=np.float64)
-        
+
         np.add.at(newNode,cell,np.broadcast_to(cb[:,None],(NC,3,2)))
-        np.add.at(patch_area,cell,np.broadcast_to(cm[:,None],(NC,3))) 
-        
+        np.add.at(patch_area,cell,np.broadcast_to(cm[:,None],(NC,3)))
+
         newNode[isBdNode] = node[isBdNode]
         newNode[isFreeNode] = newNode[isFreeNode]/patch_area[...,None][isFreeNode]
         self.node = newNode
@@ -1065,8 +1058,8 @@ class TriangleMesh(Mesh, Plotable):
         if rflag == True:
             self.ds.construct()
 
+    @staticmethod
     def adaptive_options(
-            self,
             method='mean',
             maxrefine=5,
             maxcoarsen=0,
@@ -1475,9 +1468,7 @@ class TriangleMesh(Mesh, Plotable):
         else:
             isBigSizeCell = (l > hmax) & isInterfaceCell
 
-
         return isBigCurveCell | isBigSizeCell
-
 
 
     def mark_interface_cell_with_type(self, phi, interface):
@@ -1730,7 +1721,7 @@ class TriangleMesh(Mesh, Plotable):
     ## @ingroup MeshGenerators
     @classmethod
     def from_domain_distmesh(cls, domain, hmin, maxit=100):
-        from .DistMesher2d import DistMesher2d 
+        from .DistMesher2d import DistMesher2d
         mesher = DistMesher2d(domain, hmin)
         mesh = mesher.meshing(maxit=maxit)
         return mesh
@@ -1763,7 +1754,7 @@ class TriangleMesh(Mesh, Plotable):
         # 获取节点信息
         node_tags, node_coords, _ = gmsh.model.mesh.getNodes()
         node = node_coords.reshape((-1,3))[:,:2]
-        
+
         # 节点编号映射
         nodetags_map = dict({j:i for i,j in enumerate(node_tags)})
 


### PR DESCRIPTION
updates:
- Mesh<x>dDataStructure is now only for homogeneous mesh. So data structures like `TriangleMeshDataStructure` can inherit only from `Mesh2dDataStructure`, and `PolygonMeshDataStructure` inherits from the base directly. This is because there are so many differences between homogeneous meshes and poly ones.
- Deleted some class variables `NVC`, `NEC`, `NFC`, `NVE`, `NVF` and `NEF`, and users should use methods like `number_of_edges_of_cells()` and `number_of_faces_of_cells()` instead. This is done, for example, by
```python
cell.shape[0] #NVC
localEdge.shape[0] #NEC
localFace.shape[0] #NFC
localEdge.shape[1] #NVE
localFace.shape[1] #NVF
localFace2edge.shape[1] #NEF, only for 3d meshes
```
These 5 constants are only available for homogeneous meshes.
- There are still large diffs, but most of them were deletions of trailing whitespaces, automatically done by vscode.