### PR TITLE
update mesh data structure base

### DIFF
--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -20,10 +20,8 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     localEdge = np.array([(0, 1)], dtype=np.int_)
     localFace = np.array([(0, ), (1, )], dtype=np.int_)
 
-    ### cell ###
 
-    def cell_to_node(self) -> NDArray:
-        return self.cell
+    ### Special Topology APIs for Non-structures ###
 
     def cell_to_edge(self) -> NDArray:
         NC = self.number_of_cells()
@@ -32,20 +30,15 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     def cell_to_face(self) -> NDArray:
         return self.cell
 
-    ### face ###
-
     def face_to_cell(self) -> NDArray:
         return self.face2cell
 
+
+    ### General Topology APIs ###
+
     face_to_edge = face_to_cell
-
-    ### edge ###
-
     edge_to_face = cell_to_face
     edge_to_cell = cell_to_edge
-
-    ### node ###
-
     node_to_edge = face_to_cell
     node_to_cell = face_to_cell
 

--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -14,6 +14,7 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     """
     # Variables
     edge = ArrRedirector('cell')
+    face = ArrRedirector('face_')
 
     # Constants
     TD = 1
@@ -22,8 +23,8 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    def cell_to_face(self) -> NDArray: # simplified for 1d case
-        return self.cell
+    def cell_to_face(self, return_sparse=False, return_local=False) -> NDArray: # simplified for 1d case
+        return self.cell_to_node(return_sparse=return_sparse, return_local=return_local)
 
     def cell_to_edge(self) -> NDArray:
         NC = self.number_of_cells()
@@ -32,17 +33,12 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
 
     ### General Topology APIs ###
 
-    def face_to_node(self):
+    @property
+    def face_(self):
         NN = self.NN
         return np.arange(NN, dtype=self.itype).reshape(NN, 1)
 
     def face_to_edge(self, return_sparse=False):
-        return self.face_to_cell(return_sparse=return_sparse)
-
-    def node_to_edge(self, return_sparse=False):
-        return self.face_to_cell(return_sparse=return_sparse)
-
-    def node_to_cell(self, return_sparse=False):
         return self.face_to_cell(return_sparse=return_sparse)
 
     def edge_to_face(self, return_sparse=False):

--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -23,24 +23,17 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    def cell_to_edge(self) -> NDArray:
-        NC = self.number_of_cells()
-        return np.arange(NC, dtype=self.itype).reshape(NC, 1)
-
-    def cell_to_face(self) -> NDArray:
+    def cell_to_face(self) -> NDArray: # simplified for 1d case
         return self.cell
-
-    def face_to_cell(self) -> NDArray:
-        return self.face2cell
 
 
     ### General Topology APIs ###
 
-    face_to_edge = face_to_cell
+    face_to_edge = HomogeneousMeshDS.face_to_cell
     edge_to_face = cell_to_face
-    edge_to_cell = cell_to_edge
-    node_to_edge = face_to_cell
-    node_to_cell = face_to_cell
+    edge_to_cell = HomogeneousMeshDS.cell_to_edge
+    node_to_edge = HomogeneousMeshDS.face_to_cell
+    node_to_cell = HomogeneousMeshDS.face_to_cell
 
 
 class StructureMesh1dDataStructure(StructureMeshDS, Mesh1dDataStructure):

--- a/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh1d_ds.py
@@ -20,25 +20,90 @@ class Mesh1dDataStructure(HomogeneousMeshDS):
     localEdge = np.array([(0, 1)], dtype=np.int_)
     localFace = np.array([(0, ), (1, )], dtype=np.int_)
 
-
     ### Special Topology APIs for Non-structures ###
 
     def cell_to_face(self) -> NDArray: # simplified for 1d case
         return self.cell
 
+    def cell_to_edge(self) -> NDArray:
+        NC = self.number_of_cells()
+        return np.arange(NC, dtype=self.itype).reshape(NC, 1)
+
 
     ### General Topology APIs ###
 
-    face_to_edge = HomogeneousMeshDS.face_to_cell
-    edge_to_face = cell_to_face
-    edge_to_cell = HomogeneousMeshDS.cell_to_edge
-    node_to_edge = HomogeneousMeshDS.face_to_cell
-    node_to_cell = HomogeneousMeshDS.face_to_cell
+    def face_to_node(self):
+        NN = self.NN
+        return np.arange(NN, dtype=self.itype).reshape(NN, 1)
+
+    def face_to_edge(self, return_sparse=False):
+        return self.face_to_cell(return_sparse=return_sparse)
+
+    def node_to_edge(self, return_sparse=False):
+        return self.face_to_cell(return_sparse=return_sparse)
+
+    def node_to_cell(self, return_sparse=False):
+        return self.face_to_cell(return_sparse=return_sparse)
+
+    def edge_to_face(self, return_sparse=False):
+        return self.cell_to_face(return_sparse=return_sparse)
+
+    def edge_to_cell(self, return_sparse=False):
+        return self.cell_to_edge(return_sparse=return_sparse)
+
+
+    # boundary, simplified for 1d
+
+    def boundary_node_flag(self):
+        """
+        @brief Determine boundary nodes in the 1D structure mesh.
+
+        @return isBdNode : np.array, dtype=np.bool_
+            An array of booleans where True indicates a boundary node.
+        """
+        isBdNode = np.zeros(self.NN, dtype=np.bool_)
+        isBdNode[0] = True
+        isBdNode[-1] = True
+        return isBdNode
+
+    def boundary_cell_flag(self):
+        """
+        @brief Determine boundary cells in the 1D structure mesh.
+
+        @return isBdCell : np.array, dtype=np.bool_
+            An array of booleans where True indicates a boundary cell.
+        """
+        NC = self.number_of_cells()
+        isBdCell = np.zeros((NC,), dtype=np.bool_)
+        isBdCell[0] = True
+        isBdCell[-1] = True
+        return isBdCell
+
+    def boundary_node_index(self):
+        """
+        @brief Get the indices of boundary nodes in the 1D structure mesh.
+
+        @return boundary_node_indices : np.array, dtype=self.itype
+            An array containing the indices of the boundary nodes.
+        """
+        return np.array([0, self.NN-1], dtype=self.itype)
+
+    def boundary_cell_index(self):
+        """
+        @brief Get the indices of boundary cells in the 1D structure mesh.
+
+        This function returns an array containing the indices of the
+        boundary cells in the mesh.
+
+        @return boundary_cell_indices : np.array, dtype=self.itype
+            An array containing the indices of the boundary cells.
+        """
+        return np.array([0, self.NC-1], dtype=self.itype)
 
 
 class StructureMesh1dDataStructure(StructureMeshDS, Mesh1dDataStructure):
 
-    def face_to_cell(self) -> NDArray:
+    def face_to_cell(self, return_sparse=False) -> NDArray:
         """
         @TODO
         """

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -22,8 +22,8 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    def cell_to_edge(self, return_sparse=False):
-        return self.cell_to_face(return_sparse=return_sparse)
+    def cell_to_edge(self, return_sparse=False, return_local=False):
+        return self.cell_to_face(return_sparse=return_sparse, return_local=return_local)
 
     def cell_to_cell(self, return_sparse=False, return_boundary=True, return_array=False):
         """ Consctruct the neighbor information of cells
@@ -87,8 +87,8 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
     def cell_to_face_sign(self):
         return self.cell_to_edge_sign()
 
-    def edge_to_cell(self):
-        return self.face_to_cell()
+    def edge_to_cell(self, return_sparse=False):
+        return self.face_to_cell(return_sparse=return_sparse)
 
     def node_to_node(self, return_array=False):
 
@@ -129,17 +129,6 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
         val = np.ones(2*edge.shape[0], dtype=np.bool_)
         node2node = csr_matrix((val, (I, J)), shape=(NN, NN), dtype=np.bool_)
         return node2node
-
-    def node_to_edge(self):
-        return arr_to_csr(self.edge, self.number_of_nodes(), reversed=True)
-
-    def node_to_face(self):
-        return self.node_to_edge()
-
-    def node_to_cell(self, return_localidx=False):
-        return arr_to_csr(self.cell, self.number_of_nodes(),
-                          reversed=True, return_local=return_localidx,
-                          dtype=self.itype)
 
 
     ### boundary ###

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -22,6 +22,9 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
+    def cell_to_edge(self, return_sparse=False):
+        return self.cell_to_face(return_sparse=return_sparse)
+
     def cell_to_cell(self, return_sparse=False, return_boundary=True, return_array=False):
         """ Consctruct the neighbor information of cells
         """
@@ -81,9 +84,11 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
 
         return cell2edgeSign
 
-    cell_to_face_sign = cell_to_edge_sign
+    def cell_to_face_sign(self):
+        return self.cell_to_edge_sign()
 
-    edge_to_cell = HomogeneousMeshDS.face_to_cell
+    def edge_to_cell(self):
+        return self.face_to_cell()
 
     def node_to_node(self, return_array=False):
 

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -22,23 +22,6 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    def cell_to_edge(self):
-        """
-        @brief The neighbor information of cell to edge
-        """
-        NE = self.number_of_edges()
-        NC = self.number_of_cells()
-        NEC = self.number_of_edges_of_cells()
-
-        edge2cell = self.edge2cell
-
-        cell2edge = np.zeros((NC, NEC), dtype=self.itype)
-        cell2edge[edge2cell[:, 0], edge2cell[:, 2]] = np.arange(NE)
-        cell2edge[edge2cell[:, 1], edge2cell[:, 3]] = np.arange(NE)
-        return cell2edge
-
-    cell_to_face = cell_to_edge
-
     def cell_to_cell(self, return_sparse=False, return_boundary=True, return_array=False):
         """ Consctruct the neighbor information of cells
         """
@@ -84,9 +67,6 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
                 adjLocation[1:] = np.cumsum(nn)
                 return adj.astype(np.int32), adjLocation
 
-    def face_to_cell(self):
-        return self.edge2cell
-
 
     ### General Topology APIs ###
 
@@ -103,7 +83,7 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
 
     cell_to_face_sign = cell_to_edge_sign
 
-    edge_to_cell = face_to_cell
+    edge_to_cell = HomogeneousMeshDS.face_to_cell
 
     def node_to_node(self, return_array=False):
 

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -19,10 +19,8 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
     # Constants
     TD: int = 2
 
-    ### cell ###
 
-    def cell_to_node(self) -> NDArray:
-        return self.cell
+    ### Special Topology APIs for Non-structures ###
 
     def cell_to_edge(self):
         """
@@ -39,19 +37,7 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
         cell2edge[edge2cell[:, 1], edge2cell[:, 3]] = np.arange(NE)
         return cell2edge
 
-    def cell_to_edge_sign(self):
-        NC = self.number_of_cells()
-        NEC = self.number_of_edges_of_cells()
-
-        edge2cell = self.edge2cell
-
-        cell2edgeSign = np.zeros((NC, NEC), dtype=np.bool_)
-        cell2edgeSign[edge2cell[:, 0], edge2cell[:, 2]] = True
-
-        return cell2edgeSign
-
     cell_to_face = cell_to_edge
-    cell_to_face_sign = cell_to_edge_sign
 
     def cell_to_cell(self, return_sparse=False, return_boundary=True, return_array=False):
         """ Consctruct the neighbor information of cells
@@ -98,16 +84,26 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
                 adjLocation[1:] = np.cumsum(nn)
                 return adj.astype(np.int32), adjLocation
 
-    ### face ###
-
     def face_to_cell(self):
         return self.edge2cell
 
-    ### edge ###
+
+    ### General Topology APIs ###
+
+    def cell_to_edge_sign(self):
+        NC = self.number_of_cells()
+        NEC = self.number_of_edges_of_cells()
+
+        edge2cell = self.edge2cell
+
+        cell2edgeSign = np.zeros((NC, NEC), dtype=np.bool_)
+        cell2edgeSign[edge2cell[:, 0], edge2cell[:, 2]] = True
+
+        return cell2edgeSign
+
+    cell_to_face_sign = cell_to_edge_sign
 
     edge_to_cell = face_to_cell
-
-    ### node ###
 
     def node_to_node(self, return_array=False):
 

--- a/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh2d_ds.py
@@ -5,7 +5,7 @@ from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
 from .mesh_ds import ArrRedirector, HomogeneousMeshDS, StructureMeshDS
-
+from .sparse_tool import arr_to_csr
 
 class Mesh2dDataStructure(HomogeneousMeshDS):
     """
@@ -131,36 +131,16 @@ class Mesh2dDataStructure(HomogeneousMeshDS):
         return node2node
 
     def node_to_edge(self):
-        """
-        """
-        NN = self.number_of_nodes()
-        NE = self.number_of_edges()
-        NVE = self.NVE
-        I = self.edge.flat
-        J = np.repeat(range(NE), NVE)
-        val = np.ones(NVE*NE, dtype=np.bool_)
-        node2edge = csr_matrix((val, (I, J)), shape=(NN, NE))
-        return node2edge
+        return arr_to_csr(self.edge, self.number_of_nodes(), reversed=True)
 
-    node_to_face = node_to_edge
+    def node_to_face(self):
+        return self.node_to_edge()
 
     def node_to_cell(self, return_localidx=False):
-        """
-        """
-        NN = self.number_of_nodes()
-        NC = self.number_of_cells()
-        NVC = self.number_of_vertices_of_cells()
+        return arr_to_csr(self.cell, self.number_of_nodes(),
+                          reversed=True, return_local=return_localidx,
+                          dtype=self.itype)
 
-        I = self.cell.flat
-        J = np.repeat(range(NC), NVC)
-
-        if return_localidx == False:
-            val = np.ones(NVC*NC, dtype=np.bool_)
-            node2cell = csr_matrix((val, (I, J)), shape=(NN, NC))
-        else:
-            val = ranges(NVC*np.ones(NC, dtype=self.itype), start=1)
-            node2cell = csr_matrix((val, (I, J)), shape=(NN, NC), dtype=self.itype)
-        return node2cell
 
     ### boundary ###
 

--- a/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
@@ -5,6 +5,7 @@ from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
 from .mesh_ds import HomogeneousMeshDS, StructureMeshDS
+from .sparse_tool import enable_csr
 
 
 class Mesh3dDataStructure(HomogeneousMeshDS):
@@ -31,6 +32,10 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
 
 
     ### Special Topology APIs for Non-structures ###
+
+    @enable_csr
+    def cell_to_edge(self):
+        return self.cell2edge
 
     def cell_to_cell(
             self, return_sparse=False,

--- a/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
@@ -5,7 +5,7 @@ from scipy.sparse import coo_matrix, csr_matrix
 
 from ...common import ranges
 from .mesh_ds import HomogeneousMeshDS, StructureMeshDS
-from .sparse_tool import enable_csr
+from .sparse_tool import arr_to_csr
 
 
 class Mesh3dDataStructure(HomogeneousMeshDS):
@@ -33,9 +33,12 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    @enable_csr
-    def cell_to_edge(self):
-        return self.cell2edge
+    def cell_to_edge(self, return_sparse=False, return_local=False):
+        if not return_sparse:
+            return self.cell2edge
+        else:
+            return arr_to_csr(self.cell2edge, self.number_of_edges(),
+                              return_local=return_local, dtype=self.itype)
 
     def cell_to_cell(
             self, return_sparse=False,

--- a/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
@@ -29,7 +29,8 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
         """
         return self.localFace2edge.shape[1]
 
-    ### Cell ###
+
+    ### Special Topology APIs for Non-structures ###
 
     def cell_to_edge(self, return_sparse=False):
         """ The neighbor information of cell to edge
@@ -51,21 +52,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
                     ), shape=(NC, NE))
             return cell2edge
 
-    def cell_to_edge_sign(self, cell=None):
-        """
-        TODO: check here
-        """
-        if cell==None:
-            cell = self.cell
-        NC = self.number_of_cells()
-        NEC = self.number_of_edges_of_cells()
-        cell2edgeSign = np.zeros((NC, NEC), dtype=np.bool_)
-        localEdge = self.localEdge
-        E = localEdge.shape[0]
-        for i, (j, k) in zip(range(E), localEdge):
-            cell2edgeSign[:, i] = cell[:, j] < cell[:, k]
-        return cell2edgeSign
-
     def cell_to_face(self):
         NC = self.number_of_cells()
         NF = self.number_of_faces()
@@ -75,16 +61,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
         cell2face[face2cell[:, 0], face2cell[:, 2]] = range(NF)
         cell2face[face2cell[:, 1], face2cell[:, 3]] = range(NF)
         return cell2face
-
-    def cell_to_face_sign(self):
-        """
-        """
-        NC = self.number_of_cells()
-        face2cell = self.face2cell
-        NFC = self.number_of_faces_of_cells()
-        cell2facesign = np.zeros((NC, NFC), dtype=np.bool_)
-        cell2facesign[face2cell[:, 0], face2cell[:, 2]] = True
-        return cell2facesign
 
     def cell_to_cell(
             self, return_sparse=False,
@@ -100,7 +76,7 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
 
         face2cell = self.face2cell
         if (return_sparse is False) and (return_array is False):
-            NFC = self.NFC
+            NFC = self.number_of_faces_of_cells()
             cell2cell = np.zeros((NC, NFC), dtype=self.itype)
             cell2cell[face2cell[:, 0], face2cell[:, 2]] = face2cell[:, 1]
             cell2cell[face2cell[:, 1], face2cell[:, 3]] = face2cell[:, 0]
@@ -138,8 +114,49 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
                 adjLocation[1:] = np.cumsum(nn)
                 return adj.astype(np.int32), adjLocation
 
+    def face_to_cell(self, return_sparse=False):
+        if return_sparse is False:
+            return self.face2cell
+        else:
+            NC = self.number_of_cells()
+            NF = self.number_of_faces()
+            face2cell = csr_matrix(
+                    (
+                        np.ones(2*NF, dtype=np.bool_),
+                        (
+                            np.repeat(range(NF), 2),
+                            self.face2cell[:, [0, 1]].flat
+                        )
+                    ), shape=(NF, NC), dtype=np.bool_)
+            return face2cell
 
-    ### face ###
+
+    ### General Topology APIs ###
+
+    def cell_to_edge_sign(self, cell=None):
+        """
+        TODO: check here
+        """
+        if cell==None:
+            cell = self.cell
+        NC = self.number_of_cells()
+        NEC = self.number_of_edges_of_cells()
+        cell2edgeSign = np.zeros((NC, NEC), dtype=np.bool_)
+        localEdge = self.localEdge
+        E = localEdge.shape[0]
+        for i, (j, k) in zip(range(E), localEdge):
+            cell2edgeSign[:, i] = cell[:, j] < cell[:, k]
+        return cell2edgeSign
+
+    def cell_to_face_sign(self):
+        """
+        """
+        NC = self.number_of_cells()
+        face2cell = self.face2cell
+        NFC = self.number_of_faces_of_cells()
+        cell2facesign = np.zeros((NC, NFC), dtype=np.bool_)
+        cell2facesign[face2cell[:, 0], face2cell[:, 2]] = True
+        return cell2facesign
 
     def face_to_edge(self, return_sparse=False):
         cell2edge = self.cell2edge
@@ -169,25 +186,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
         face2edge = self.face_to_edge(return_sparse=True)
         return face2edge*face2edge.T
 
-    def face_to_cell(self, return_sparse=False):
-        if return_sparse is False:
-            return self.face2cell
-        else:
-            NC = self.number_of_cells()
-            NF = self.number_of_faces()
-            face2cell = csr_matrix(
-                    (
-                        np.ones(2*NF, dtype=np.bool_),
-                        (
-                            np.repeat(range(NF), 2),
-                            self.face2cell[:, [0, 1]].flat
-                        )
-                    ), shape=(NF, NC), dtype=np.bool_)
-            return face2cell
-
-
-    ### edge ###
-
     def edge_to_edge(self):
         edge2node = self.edge_to_node(return_sparse=True)
         return edge2node*edge2node.T
@@ -196,7 +194,7 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
         NF = self.number_of_faces()
         NE = self.number_of_edges()
         face2edge = self.face_to_edge()
-        NEF = self.NEF
+        NEF = self.number_of_edges_of_faces()
         edge2face = csr_matrix(
                 (
                     np.ones(NEF*NF, dtype=np.bool_),
@@ -226,9 +224,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
             raise ValueError("Need to implement!")
 
         return edge2cell
-
-
-    ### Node ###
 
     def node_to_node(self):
         """ The neighbor information of nodes

--- a/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh3d_ds.py
@@ -32,36 +32,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
 
     ### Special Topology APIs for Non-structures ###
 
-    def cell_to_edge(self, return_sparse=False):
-        """ The neighbor information of cell to edge
-        """
-        if return_sparse is False:
-            return self.cell2edge
-        else:
-            NC = self.number_of_cells()
-            NE = self.number_of_edges()
-            cell2edge = coo_matrix((NC, NE), dtype=np.bool_)
-            NEC = self.number_of_edges_of_cells()
-            cell2edge = csr_matrix(
-                    (
-                        np.ones(NEC*NC, dtype=np.bool_),
-                        (
-                            np.repeat(range(NC), NEC),
-                            self.cell2edge.flat
-                        )
-                    ), shape=(NC, NE))
-            return cell2edge
-
-    def cell_to_face(self):
-        NC = self.number_of_cells()
-        NF = self.number_of_faces()
-        face2cell = self.face2cell
-        NFC = self.number_of_faces_of_cells()
-        cell2face = np.zeros((NC, NFC), dtype=self.itype)
-        cell2face[face2cell[:, 0], face2cell[:, 2]] = range(NF)
-        cell2face[face2cell[:, 1], face2cell[:, 3]] = range(NF)
-        return cell2face
-
     def cell_to_cell(
             self, return_sparse=False,
             return_boundary=True, return_array=False):
@@ -114,22 +84,6 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
                 adjLocation[1:] = np.cumsum(nn)
                 return adj.astype(np.int32), adjLocation
 
-    def face_to_cell(self, return_sparse=False):
-        if return_sparse is False:
-            return self.face2cell
-        else:
-            NC = self.number_of_cells()
-            NF = self.number_of_faces()
-            face2cell = csr_matrix(
-                    (
-                        np.ones(2*NF, dtype=np.bool_),
-                        (
-                            np.repeat(range(NF), 2),
-                            self.face2cell[:, [0, 1]].flat
-                        )
-                    ), shape=(NF, NC), dtype=np.bool_)
-            return face2cell
-
 
     ### General Topology APIs ###
 
@@ -171,7 +125,7 @@ class Mesh3dDataStructure(HomogeneousMeshDS):
         else:
             NF = self.number_of_faces()
             NE = self.number_of_edges()
-            NEF = self.NEF
+            NEF = self.number_of_edges_of_faces()
             f2e = csr_matrix(
                     (
                         np.ones(NEF*NF, dtype=np.bool_),

--- a/fealpy/mesh/mesh_data_structure/mesh_ds.py
+++ b/fealpy/mesh/mesh_data_structure/mesh_ds.py
@@ -99,7 +99,7 @@ class MeshDataStructure():
         """
         @brief Return neighbor information from cell to node.
         """
-        raise NotImplementedError
+        return self.cell
 
     def cell_to_edge(self, *args, **kwargs) -> NDArray:
         raise NotImplementedError
@@ -109,6 +109,12 @@ class MeshDataStructure():
 
     def face_to_cell(self, *args, **kwargs) -> NDArray:
         raise NotImplementedError
+
+    def face_to_node(self, return_sparse: bool=False):
+        return self.face
+
+    def edge_to_node(self, return_sparse: bool=False):
+        return self.edge
 
 
     # boundary flag

--- a/fealpy/mesh/mesh_data_structure/sparse_tool.py
+++ b/fealpy/mesh/mesh_data_structure/sparse_tool.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, overload, Literal
 from scipy.sparse import csr_matrix
 from numpy.typing import NDArray
 import numpy as np
@@ -9,7 +9,11 @@ def enable_csr(fn: Callable[..., NDArray]):
     @brief Make a function generating neighborhood infomation matrix\
            supporting csr matrix output.
     """
-    def wrapped(self, *args, return_sparse: bool=False, **kwargs):
+    @overload
+    def wrapped(self, *args, return_sparse: Literal[False], **kwargs) -> NDArray: ...
+    @overload
+    def wrapped(self, *args, return_sparse: Literal[True], **kwargs) -> csr_matrix: ...
+    def wrapped(self, *args, return_sparse=False, **kwargs):
         ret = fn(self, *args, **kwargs)
         if return_sparse:
             if ret.ndim != 2:

--- a/fealpy/mesh/mesh_data_structure/sparse_tool.py
+++ b/fealpy/mesh/mesh_data_structure/sparse_tool.py
@@ -18,7 +18,8 @@ def enable_csr(fn: Callable[..., NDArray]):
         if return_sparse:
             if ret.ndim != 2:
                 raise ValueError("Can only tackle tensors with 2 dimension.")
-            nr, nc = ret.shape
+            nr, _ = ret.shape
+            nc = np.max(ret) + 1
             sp = csr_matrix(
                 (
                     np.ones(nr*nc, dtype=np.bool_),

--- a/fealpy/mesh/mesh_data_structure/sparse_tool.py
+++ b/fealpy/mesh/mesh_data_structure/sparse_tool.py
@@ -1,7 +1,9 @@
-from typing import Callable, overload, Literal
+from typing import Callable, overload, Literal, Optional
 from scipy.sparse import csr_matrix
 from numpy.typing import NDArray
 import numpy as np
+
+from ...common import ranges
 
 
 def enable_csr(fn: Callable[..., NDArray]):
@@ -16,23 +18,63 @@ def enable_csr(fn: Callable[..., NDArray]):
     def wrapped(self, *args, return_sparse=False, **kwargs):
         ret = fn(self, *args, **kwargs)
         if return_sparse:
-            if ret.ndim != 2:
-                raise ValueError("Can only tackle tensors with 2 dimension.")
-            nr, _ = ret.shape
-            nc = np.max(ret) + 1
-            sp = csr_matrix(
-                (
-                    np.ones(nr*nc, dtype=np.bool_),
-                    (
-                        np.repeat(range(nr), nc),
-                        ret.flat
-                    )
-                ),
-                shape=(nr, nc)
-            )
-            return sp
-
+            return arr_to_csr(arr=ret, reversed=False)
         else:
             return ret
 
     return wrapped
+
+
+def arr_to_csr(arr: NDArray, n_col: Optional[int]=None,
+               reversed=False, return_local=False, dtype=np.int_):
+    """
+    @brief Convert neighbor information matrix to sparse type.
+
+    @param arr: NDArray.
+    @param n_col: int, optional. Number of columns of the output. For example,\
+                  when converting `cell_to_edge` to sparse, `n_col` should be the\
+                  number of edges, alse will be the number of columns of the output\
+                  sparse matrix. If not provided, use `max(arr) + 1` instead.
+    @param reversed: bool, defaults to False. Transpose the sparse matrix if True,\
+                     then the relationship will be reversed.
+    @oaram return_local: bool, deaults to False.
+    @param dtype: np.dtype.
+    """
+    if arr.ndim != 2:
+        raise ValueError("Can only tackle tensors with 2 dimension.")
+    nr, nv = arr.shape
+
+    if n_col is not None:
+        nc = n_col
+    else:
+        nc = np.max(arr) + 1
+
+    if not return_local:
+        val = np.ones(nr*nv, dtype=np.bool_)
+    else:
+        val = ranges(nv*np.ones(nr, dtype=dtype), start=1)
+
+    if not reversed:
+        sp = csr_matrix(
+            (
+                val,
+                (
+                    np.repeat(range(nr), nv),
+                    arr.flat
+                )
+            ),
+            shape=(nr, nc)
+        )
+        return sp
+    else:
+        sp = csr_matrix(
+            (
+                val,
+                (
+                    arr.flat,
+                    np.repeat(range(nr), nv)
+                )
+            ),
+            shape=(nc, nr)
+        )
+        return sp


### PR DESCRIPTION
### update:
- a function `arr_to_csr` can help convert an array to a sparse one. It accepts parameters `return_local` and `reversed`.
- Move 6 topology relationship method to `HomogeneousMeshDS`, and most of them supports `return_sparse` and `return_local`(show local index in sparse matrix), and the reverse relations(such as `cell_to_edge` to the `edge_to_cell`) of them are implemented.