### PR TITLE
修改mesh.py文件中的漏洞。

### DIFF
--- a/fealpy/mesh/mesh_base/mesh.py
+++ b/fealpy/mesh/mesh_base/mesh.py
@@ -407,11 +407,11 @@ class Mesh():
                 elif v.coordtype == 'barycentric':
                     v = v(bcs)
 
-        #if u.shape[-1] == 1:
-        #    u = u[..., 0]
+        if u.shape[-1] == 1:
+           u = u[..., 0]
 
-        #if v.shape[-1] == 1:
-        #    v = v[..., 0]
+        if v.shape[-1] == 1:
+           v = v[..., 0]
 
         cm = self.entity_measure('cell')
 


### PR DESCRIPTION
对于 mesh 中的 error() 函数，取消原来对下面这段代码的注释：
        if u.shape[-1] == 1:
           u = u[..., 0]
        if v.shape[-1] == 1:
           v = v[..., 0]
因为发现对于一维网格，没有这段代码会出现无法广播的情况。    