### PR TITLE
update: add cell_to_cell

### DIFF
--- a/fealpy/pinn/modules/module.py
+++ b/fealpy/pinn/modules/module.py
@@ -54,7 +54,7 @@ class TensorMapping(Module):
 
         @note: This is a method with coordtype 'cartesian'.
         """
-        pt = torch.from_numpy(ps).float()
+        pt = torch.from_numpy(ps)
         return self.forward(pt)
 
     from_numpy.__dict__['coordtype'] = 'cartesian'


### PR DESCRIPTION
### Update
- Add `cell_to_cell`, `edge_to_edge` and `node_to_node` to mesh data structure base. Now, `cell_to_cell` is only for homogeneous meshes while `edge_to_edge` and `node_to_node` are avaible for all types of meshes.