### PR TITLE
Add rfm method for Helmholtz_2d

### DIFF
--- a/example/ml/Helmholtz_example1_rfm_dirchlet_2d.py
+++ b/example/ml/Helmholtz_example1_rfm_dirchlet_2d.py
@@ -1,0 +1,109 @@
+from math import sqrt
+
+import torch
+from torch import Tensor, sin
+from scipy.sparse.linalg import spsolve
+from scipy.sparse import csr_matrix
+
+from fealpy.ml.modules import RandomFeaturePoUSpace, PoUSin, Cos, RFFunction, Solution
+from fealpy.mesh import UniformMesh2d, TriangleMesh
+
+#方程形式
+
+"""
+    \Delta u(x,y) + 200 * u(x,y) = 0 ,   (x,y)\in \Omega
+    u(x,y) = \sin(10*x + 10*y) ,         (x,y)\in \partial\Omega
+
+"""
+k = torch.sqrt(torch.tensor(200))#波数
+
+#真解
+
+def real_solution(p: Tensor):
+    x = p[:, 0:1]
+    y = p[:, 1:2]
+    return sin(10 * x + 10 * y)
+
+#边界条件
+
+def boundary(p: Tensor):
+    return real_solution(p)
+
+#源项
+
+def source(p: Tensor):
+    x = p[:, 0:1]
+    return torch.zeros_like(x)
+
+#超参数
+
+EXT = 2
+H = 2*1/EXT
+Jn = 512
+
+EXTC = 90
+HC = 2*1/EXTC
+
+#用网格进行配置点采样
+
+mesh = UniformMesh2d((0, EXT, 0, EXT), (H, H), origin=(-1, -1))
+node = torch.from_numpy(mesh.entity('node')).clone()
+space = RandomFeaturePoUSpace(2, Jn, Cos(), PoUSin(), centers=node, radius=H/2,
+                              bound=(k, torch.pi), print_status=True)
+
+
+mesh_col = UniformMesh2d((0, EXTC, 0, EXTC), (HC, HC), origin=(-1, -1))
+_bd_node = mesh_col.ds.boundary_node_flag()
+col_in = torch.from_numpy(mesh_col.entity('node', index=~_bd_node))
+col_bd = torch.from_numpy(mesh_col.entity('node', index=_bd_node))
+
+mesh_err = TriangleMesh.from_box([-1, 1, -1, 1], nx=50, ny=50)
+
+#计算基函数的值
+
+laplace_phi = space.L(col_in) / sqrt(col_in.shape[0])
+phi_in = space.U(col_in) / sqrt(col_in.shape[0])
+phi_bd = space.U(col_bd) / sqrt(col_bd.shape[0])
+
+#组装矩阵
+
+A_tensor = torch.cat([laplace_phi + k**2 * phi_in,
+                      phi_bd], dim=0)
+b_tensor = torch.cat([source(col_in) / sqrt(col_in.shape[0]),
+                      boundary(col_bd) / sqrt(col_bd.shape[0])], dim=0)
+
+
+A = csr_matrix(A_tensor.cpu().numpy())
+b = csr_matrix(b_tensor.cpu().numpy())
+
+um = spsolve(A.T@A, A.T@b)
+solution = RFFunction(space, torch.from_numpy(um))
+
+#计算L2误差
+
+error = solution.estimate_error_tensor(real_solution, mesh=mesh_err)
+print(f"L-2 error: {error.data}")
+
+# 可视化
+
+from matplotlib import pyplot as plt
+fig = plt.figure()
+axes = fig.add_subplot(131, projection='3d')
+solution.add_surface(axes, box=[-1, 1, -1, 1], nums=[40, 40])
+axes.set_xlabel('x')
+axes.set_ylabel('y')
+axes.set_zlabel('phi')
+
+axes = fig.add_subplot(132, projection='3d')
+Solution(real_solution).add_surface(axes, box=[-1, 1, -1, 1], nums=[40, 40])
+axes.set_xlabel('x')
+axes.set_ylabel('y')
+axes.set_zlabel('phi')
+
+axes = fig.add_subplot(133, projection='3d')
+solution.diff(real_solution).add_surface(axes, box=[-1, 1, -1, 1], nums=[40, 40])
+axes.set_xlabel('x')
+axes.set_ylabel('y')
+axes.set_zlabel('phi')
+
+plt.show()

--- a/example/ml/Helmholtz_example2_PIKFNN_dirichlet_2d.py
+++ b/example/ml/Helmholtz_example2_PIKFNN_dirichlet_2d.py
@@ -12,7 +12,9 @@ from fealpy.mesh import TriangleMesh
 
 from uniformly_placed import sample_points_on_circle
 from Levenberg_Marquardt_algorithm import minimize_levmarq
+
 #方程形式
+
 """
     \Delta u(x,y) + k**2 * u(x,y) = 0 ,   (x,y)\in \Omega
     u(x,y) = \sin(k*x + k*y) ,         (x,y)\in \partial\Omega
@@ -20,11 +22,13 @@ from Levenberg_Marquardt_algorithm import minimize_levmarq
 """
 
 #超参数(配置点个数、源点个数)
+
 NN = 300
 NS = 300
 k = torch.tensor(100) #波数
 
 #PIKF层
+
 class PIKF_layer(nn.Module):
     def __init__(self, source_nodes: Tensor) -> None:
         super().__init__()
@@ -41,10 +45,12 @@ class PIKF_layer(nn.Module):
         return self.kernel_func(p)
 
 #对配置点和源点进行采样
+
 source_nodes = sample_points_on_circle(0, 0, 3, NS)#源点在虚假边界上采样
 nodes_on_bc = sample_points_on_circle(0.0, 0.0, 1.0 , NN)
 
 #PIKFNN的网络结构
+
 pikf_layer = PIKF_layer(source_nodes)
 net_PIKFNN = nn.Sequential(
                            pikf_layer,
@@ -58,9 +64,11 @@ def init_weights(m):
 net_PIKFNN.apply(init_weights)
 
 #网络实例化
+
 s = Solution(net_PIKFNN)
 
 #真解
+
 def solution(p:torch.Tensor) -> torch.Tensor:
 
     x = p[...,0:1]
@@ -69,14 +77,17 @@ def solution(p:torch.Tensor) -> torch.Tensor:
     return torch.sin(k*x) + torch.cos(k*y)
 
 #边界条件
+
 def bc(p:torch.Tensor, u) -> torch.Tensor:
     return u - solution(p)
 
 #构建网格用于计算误差
+
 mesh = TriangleMesh.from_unit_circle_gmsh(0.02)
 sampler_err = get_mesh_sampler(10, mesh)
 
 #提取网络层参数并更新
+
 weight = net_PIKFNN[1].weight
 xs = weight.view(-1,1)
 basis = pikf_layer(nodes_on_bc)
@@ -92,6 +103,7 @@ weight_1 = net_PIKFNN[1].weight
 xs_new = weight_1.view(-1,1)
 
 #计算两种误差
+
 L2_error = torch.sqrt(
             torch.sum((basis @ xs_new - solution(nodes_on_bc))**2, dim = 0)\
             /torch.sum(solution(nodes_on_bc)**2, dim = 0)
@@ -101,6 +113,7 @@ error = linf_error(s, solution, sampler=sampler_err)
 print(f"error: {error}")
 
 #可视化真解u和数值解u_PIKFNN
+
 bc_ = np.array([1/3, 1/3, 1/3])
 ps = torch.tensor(mesh.bc_to_point(bc_), dtype=torch.float64)
 


### PR DESCRIPTION
1. 增加了rfm方法求解Helmholtz方程的例子，对于论文中的第一个例子（波数为根号200），精度在E-5和E-6之间，效果要好于PIKFNN方法。