### PR TITLE
update ML module

### DIFF
--- a/example/ml/rfm/heat_equation1d.py
+++ b/example/ml/rfm/heat_equation1d.py
@@ -9,7 +9,7 @@ from torch import Tensor, exp, sin
 from scipy.sparse.linalg import spsolve
 from scipy.sparse import csr_matrix
 
-from fealpy.ml.modules import RandomFeaturePoUSpace, PoUSin, Cos, RFFunction
+from fealpy.ml.modules import RandomFeaturePoUSpace, PoUSin, Cos, Function
 from fealpy.mesh import UniformMesh2d, TriangleMesh
 
 
@@ -64,7 +64,7 @@ A = csr_matrix(A_tensor.cpu().numpy())
 b = csr_matrix(b_tensor.cpu().numpy())
 
 um = spsolve(A.T@A, A.T@b)
-solution = RFFunction(space, torch.from_numpy(um))
+solution = Function(space, torch.from_numpy(um))
 
 
 error = solution.estimate_error_tensor(real_solution, mesh=mesh_err)
@@ -81,10 +81,10 @@ axes.set_xlabel('x')
 axes.set_ylabel('y')
 axes.set_zlabel('phi')
 
-axes = fig.add_subplot(122, projection='3d')
-solution.diff(real_solution).add_surface(axes, box=[0, 1, 0, 1], nums=[40, 40])
+axes = fig.add_subplot(122)
+qm = solution.diff(real_solution).add_pcolor(axes, box=[0, 1, 0, 1], nums=[40, 40])
 axes.set_xlabel('x')
 axes.set_ylabel('y')
-axes.set_zlabel('phi')
+fig.colorbar(qm)
 
 plt.show()

--- a/example/ml/rfm/poisson2d.py
+++ b/example/ml/rfm/poisson2d.py
@@ -9,7 +9,7 @@ from torch import Tensor, cos
 from scipy.sparse.linalg import spsolve
 from scipy.sparse import csr_matrix
 
-from fealpy.ml.modules import RandomFeaturePoUSpace, PoUSin, Cos, RFFunction
+from fealpy.ml.modules import RandomFeaturePoUSpace, PoUSin, Cos, Function
 from fealpy.mesh import UniformMesh2d, TriangleMesh
 
 NEW_BASIS = False
@@ -71,7 +71,7 @@ A = csr_matrix(A_tensor.cpu().numpy())
 b = csr_matrix(b_tensor.cpu().numpy())
 
 um = spsolve(A.T@A, A.T@b)
-solution = RFFunction(space, torch.from_numpy(um))
+solution = Function(space, torch.from_numpy(um))
 end_time = time()
 
 error = solution.estimate_error_tensor(real_solution, mesh=mesh_err)

--- a/fealpy/ml/modules/__init__.py
+++ b/fealpy/ml/modules/__init__.py
@@ -1,9 +1,10 @@
 
 from .module import TensorMapping, Solution, ZeroMapping, Fixed, Extracted, Projected
+from .function_space import TensorSpace, Function
 from .linear import StackStd, MultiLinear
 from .boundary import BoxDBCSolution, BoxDBCSolution1d, BoxDBCSolution2d, BoxNBCSolution
 from .attention import GradAttention
-from .rfm import RandomFeaturePoUSpace, LocalRandomFeatureSpace, RandomFeatureSpace, RFFunction
+from .rfm import RandomFeaturePoUSpace, LocalRandomFeatureSpace, RandomFeatureSpace
 from .activate import Sin, Cos, Tanh
 from .pou import PoUA, PoUSin
 from .loss import ScaledMSELoss

--- a/fealpy/ml/modules/function_space.py
+++ b/fealpy/ml/modules/function_space.py
@@ -1,0 +1,75 @@
+
+from typing import Optional
+
+import torch
+from torch import Tensor, dtype, device
+from torch.nn import Module, Linear, init
+
+from .module import TensorMapping
+
+
+class TensorSpace(Module):
+    dtype: dtype
+    device: device
+
+    def number_of_basis(self) -> int:
+        raise NotImplementedError
+
+    def basis_value(self, p: Tensor) -> Tensor:
+        raise NotImplementedError
+
+    def value(self, um: Tensor, p: Tensor) -> Tensor:
+        func = Function(self, um=um)
+        return func(p)
+
+
+class Function(TensorMapping):
+    """
+    @brief Scaler functions in a linear function space.
+    """
+    def __init__(self, space: TensorSpace, um: Optional[Tensor]) -> None:
+        """
+        @brief Initialize a scaler function in a linear function space.
+        """
+        super().__init__()
+        dtype = space.dtype
+        device = space.device
+        M = space.number_of_basis()
+
+        self.space = space
+        self.uml = Linear(M, 1, bias=False, device=device, dtype=dtype)
+        if um is None:
+            init.zeros_(self.uml.weight)
+        else:
+            self.set_um_inplace(um)
+
+    @property
+    def dim(self):
+        return self.uml.out_features
+
+    @property
+    def um(self):
+        """
+        @brief The `um` Tensor object inside the module, with shape (1, M).
+        """
+        return self.uml.weight
+
+    def numpy(self):
+        """
+        @brief Return `um` as numpy array, with shape (M, ), where M is number of\
+               basis.
+        """
+        return self.um.detach().cpu().numpy()[0, :]
+
+    def set_um_inplace(self, value: Tensor):
+        """
+        @brief Set values of um inplace. `value` must be in shape of (1, M) or\
+               (M, ), where M is the number of basis.
+        """
+        if value.ndim == 1:
+            value = value[None, :]
+        with torch.no_grad():
+            self.uml.weight[:] = value
+
+    def forward(self, p: Tensor): # (N, 1)
+        return self.uml(self.space.basis_value(p)) # (N, 1)

--- a/fealpy/ml/modules/rfm.py
+++ b/fealpy/ml/modules/rfm.py
@@ -2,15 +2,15 @@
 Modules for the Random Feature Method
 """
 
-from typing import List, Tuple, Union, Optional
+from typing import List, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.nn import init, Linear, Module
+from torch.nn import init, Linear
 
 from ..nntyping import Operator
 from .linear import StackStd
-from .module import TensorMapping
+from .function_space import TensorSpace
 from .activate import Activation
 from .pou import PoU
 
@@ -21,7 +21,7 @@ PI = torch.pi
 ### Random Feature Models
 ################################################################################
 
-class RandomFeatureSpace(Module):
+class RandomFeatureSpace(TensorSpace):
     def __init__(self, in_dim: int, nf: int,
                  activate: Activation,
                  bound: Tuple[float, float]=(1.0, PI),
@@ -99,48 +99,6 @@ class RandomFeatureSpace(Module):
             a = self.activate.dn(self.linear(p), order)
             b = torch.prod(self.linear.weight[:, idx], dim=-1, keepdim=False)
             return torch.einsum("nf, f -> nf", a, b)
-
-
-class RFFunction(TensorMapping):
-    def __init__(self, space: RandomFeatureSpace, um: Optional[Tensor]) -> None:
-        super().__init__()
-        dtype = space.dtype
-        device = space.device
-        M = space.number_of_basis()
-
-        self.space = space
-        self.uml = Linear(M, 1, bias=False, device=device, dtype=dtype)
-        if um is None:
-            init.zeros_(self.uml.weight)
-        else:
-            self.set_um_inplace(um)
-
-    @property
-    def um(self):
-        """
-        @brief The `um` Tensor object inside the module, with shape (1, M).
-        """
-        return self.uml.weight
-
-    def numpy(self):
-        """
-        @brief Return `um` as numpy array, with shape (M, ), where M is number of\
-               basis.
-        """
-        return self.um.detach().cpu().numpy()[0, :]
-
-    def set_um_inplace(self, value: Tensor):
-        """
-        @brief Set values of um inplace. `value` must be in shape of (1, M) or\
-               (M, ), where M is the number of basis.
-        """
-        if value.ndim == 1:
-            value = value[None, :]
-        with torch.no_grad():
-            self.uml.weight[:] = value
-
-    def forward(self, x: Tensor): # (N, 1)
-        return self.uml(self.space.basis_value(x)) # (N, 1)
 
 
 class LocalRandomFeatureSpace(RandomFeatureSpace):
@@ -222,7 +180,7 @@ class LocalRandomFeatureSpace(RandomFeatureSpace):
         return ret
 
 
-class RandomFeaturePoUSpace(Module):
+class RandomFeaturePoUSpace(TensorSpace):
     def __init__(self, in_dim: int, nlrf: int, activate: Activation, pou: PoU,
                  centers: Tensor, radius: Union[float, Tensor],
                  bound: Tuple[float, float]=(1.0, PI), print_status=False) -> None:
@@ -280,14 +238,6 @@ class RandomFeaturePoUSpace(Module):
     @property
     def device(self):
         return self.std.centers.device
-
-    def forward(self, p: Tensor):
-        std = self.std(p) # (N, d) -> (N, Mp, d)
-        ret = torch.zeros((p.shape[0], 1), dtype=p.dtype, device=p.device)
-        for i in range(self.number_of_partitions()):
-            x = std[:, i, :] # (N, d)
-            ret += self.partions[i](x) # (N, 1)
-        return ret # (N, 1)
 
     def scale(self, p: Tensor, operator: Operator):
         """


### PR DESCRIPTION
### New
- A new method named `last_dim` in `TensorMapping`. This is like `forward` but it only apply on the last axis/dim of the input tensor. For models that can only tackle with inputs with 2 axis (N_sample, N_feature), this method makes it possible to accept input with higher dimensions directly. (e.g. the points coming from `bc_to_point`)
- A new base class `TensorSpace`, for all function spaces.
- A new class `Function`. `RFFunction` in rfm.py was replaced by `Function`, moved to a new file and can be used by all models, not only RFM.

### Update
- `estimate_error` now support those dimension-sensitive models by using `last_dim`.