### PR TITLE
update Mesh plotting: Add multiindex

### DIFF
--- a/fealpy/mesh/mesh_base/plot.py
+++ b/fealpy/mesh/mesh_base/plot.py
@@ -49,13 +49,15 @@ class Plotable():
         from ..plotting.classic import get_ploter
         return get_ploter('finder')(self)
 
+### set different default values for entities
+
     def find_node(self, axes, *,
             node: Optional[NDArray]=None,
             index=np.s_[:],
+            multiindex=None,
             showindex=False,
             color='r', marker='o', markersize=12,
-            fontsize=12, fontcolor='r',
-            multi_index=None) -> None:
+            fontsize=12, fontcolor='r') -> None:
         """
         @brief Show nodes in the axes.
 
@@ -75,7 +77,7 @@ class Plotable():
         if node is None:
             return self.find_entity(
                     axes, etype_or_node='node', index=index,
-                    showindex=showindex,
+                    showindex=showindex, multiindex=multiindex,
                     color=color,
                     marker=marker,
                     markersize=markersize,
@@ -91,42 +93,42 @@ class Plotable():
                     fontsize=fontsize,
                     fontcolor=fontcolor)
 
-    def find_edge(self, axes,
+    def find_edge(self, axes, *,
             index=np.s_[:],
-            showindex=False,
+            showindex=False, multiindex=None,
             color='g', marker='^', markersize=15,
             fontsize=15, fontcolor='g'):
         return self.find_entity(
                 axes, 'edge', index=index,
-                showindex=showindex,
+                showindex=showindex, multiindex=multiindex,
                 color=color,
                 marker=marker,
                 markersize=markersize,
                 fontsize=fontsize,
                 fontcolor=fontcolor)
 
-    def find_face(self, axes,
+    def find_face(self, axes, *,
             index=np.s_[:],
-            showindex=False,
+            showindex=False, multiindex=None,
             color='#673AB7', marker='d', markersize=18,
             fontsize=18, fontcolor='#673AB7'):
         return self.find_entity(
                 axes, 'face', index=index,
-                showindex=showindex,
+                showindex=showindex, multiindex=multiindex,
                 color=color,
                 marker=marker,
                 markersize=markersize,
                 fontsize=fontsize,
                 fontcolor=fontcolor)
 
-    def find_cell(self, axes,
+    def find_cell(self, axes, *,
             index=np.s_[:],
-            showindex=False,
+            showindex=False, multiindex=None,
             color='b', marker='s', markersize=21,
             fontsize=21, fontcolor='b'):
         return self.find_entity(
                 axes, 'cell', index=index,
-                showindex=showindex,
+                showindex=showindex, multiindex=multiindex,
                 color=color,
                 marker=marker,
                 markersize=markersize,

--- a/fealpy/mesh/plotting/__init__.py
+++ b/fealpy/mesh/plotting/__init__.py
@@ -4,4 +4,4 @@ Provide plotting supports for the mesh module, based on matplotlib.
 
 from .classic import MeshPloter, get_ploter
 from .classic import AddPlot1d, AddPlot2dHomo, AddPlot2dPoly, AddPlot3dHomo
-from .artist import show_index, scatter, line, poly, poly_
+from .artist import show_index, show_multi_index, scatter, line, poly, poly_

--- a/fealpy/mesh/plotting/artist.py
+++ b/fealpy/mesh/plotting/artist.py
@@ -2,7 +2,7 @@
 Provide plotting tools for given points with structure.
 """
 
-from typing import Sequence, Union
+from typing import Sequence, Union, Any
 from numpy.typing import NDArray
 from matplotlib.axes import Axes
 from mpl_toolkits.mplot3d import Axes3D
@@ -65,8 +65,22 @@ def show_index(axes: Axes, location: NDArray, number: Union[NDArray, slice],
                 fontsize=fontsize, color=fontcolor)
 
 
-def show_multi_index():
-    pass
+def show_multi_index(axes: Axes, location: NDArray, text_list: Sequence[Any],
+                     fontcolor='k', fontsize=14):
+    GD = location.shape[-1]
+    loc = _validate_geo_dim(axes, location)
+    if GD == 3:
+        for i, text in enumerate(text_list):
+            axes.text(loc[i, 0], loc[i, 1], loc[i, 2], text,
+                multialignment='center', fontsize=fontsize,
+                color=fontcolor)
+
+    else:
+        for i, text in enumerate(text_list):
+            axes.text(
+                loc[i, 0], loc[i, 1], text,
+                multialignment='center',
+                fontsize=fontsize, color=fontcolor)
 
 
 def scatter(axes: Axes, points: NDArray, color,

--- a/fealpy/mesh/plotting/classic.py
+++ b/fealpy/mesh/plotting/classic.py
@@ -128,7 +128,8 @@ class MeshPloter(Generic[_MT]):
 
 class EntityFinder(MeshPloter):
     def draw(self, etype_or_node: Union[int, str, NDArray], index=np.s_[:],
-                showindex: bool=False, color='r', marker='o', markersize=20,
+                showindex: bool=False, multiindex: Optional[Sequence[Any]]=None,
+                color='r', marker='o', markersize=20,
                 fontcolor='k', fontsize=24):
         """
         @brief Show the barycenter of each entity.
@@ -154,8 +155,12 @@ class EntityFinder(MeshPloter):
         A.scatter(axes=axes, points=bc, color=color,
                   marker=marker, markersize=markersize)
         if showindex:
-            A.show_index(axes=axes, location=bc, number=index,
-                         fontcolor=fontcolor, fontsize=fontsize)
+            if multiindex is None:
+                A.show_index(axes=axes, location=bc, number=index,
+                            fontcolor=fontcolor, fontsize=fontsize)
+            else:
+                A.show_multi_index(axes=axes, location=bc, text_list=multiindex,
+                                   fontcolor=fontcolor, fontsize=fontsize)
 
 EntityFinder.register('finder')
 


### PR DESCRIPTION
### Update
- `find_<entity>()` now support plotting custom index text, using parameter `multiindex`.

For example,
```python
mesh = TriangleMesh.from_one_triangle()
mesh.uniform_refine()

text_list = np.arange(10, mesh.ds.number_of_edge()+10)
mesh.find_edge(axes, showindex=True, multiindex=text_list)
```
This feature is available for `find_node`, `find_edge`, `find_face` and `find_cell`.

The length of multiindex can be shorter than entity, but cannot be longer.