### PR TITLE
fix bug in 3D aspect

### DIFF
--- a/fealpy/mesh/plotting/classic.py
+++ b/fealpy/mesh/plotting/classic.py
@@ -204,9 +204,9 @@ class AddPlot1d(MeshPloter):
     def draw(self):
         axes = self.current_axes
         args = self.args
+        self.set_lim(args.box)
         axes.set_aspect(args.aspect)
         self.set_show_axis(args.showaxis)
-        self.set_lim(args.box)
 
         node: NDArray = self.mesh.entity('node')
 
@@ -237,9 +237,9 @@ class AddPlot2dHomo(MeshPloter):
         """
         axes = self.current_axes
         args = self.args
+        self.set_lim(args.box)
         axes.set_aspect(args.aspect)
         self.set_show_axis(args.showaxis)
-        self.set_lim(args.box)
 
         cellcolor = args.cellcolor
         if isinstance(cellcolor, np.ndarray) and np.isreal(cellcolor[0]):
@@ -275,9 +275,9 @@ class AddPlot2dPoly(MeshPloter):
         """
         axes = self.current_axes
         args = self.args
+        self.set_lim(args.box)
         axes.set_aspect(args.aspect)
         self.set_show_axis(args.showaxis)
-        self.set_lim(args.box)
 
         cellcolor = args.cellcolor
         if isinstance(cellcolor, np.ndarray) and np.isreal(cellcolor[0]):
@@ -306,9 +306,9 @@ class AddPlot3dHomo(MeshPloter):
     def draw(self):
         axes = self.current_axes
         args = self.args
+        self.set_lim(args.box)
         axes.set_aspect(args.aspect)
         self.set_show_axis(args.showaxis)
-        self.set_lim(args.box)
 
         nodecolor = args.nodecolor
         if isinstance(nodecolor, np.ndarray) and np.isreal(nodecolor[0]):


### PR DESCRIPTION
### Update
- fix bug #444 

Now the example works well and outputs:
![torus](https://github.com/weihuayi/fealpy/assets/108785827/8acae744-b6f9-4ac9-b016-a98c8aade365)

Note: x/y/zlim should be set before aspect.