### PR TITLE
在fealpy/vem 下添加了虚单元自适应的模块

### DIFF
--- a/fealpy/mesh/halfedge_mesh.py
+++ b/fealpy/mesh/halfedge_mesh.py
@@ -1767,7 +1767,7 @@ class HalfEdgeMesh2d(Mesh, Plotable):
         clevel = self.celldata['level']
 
         if ('HB' in options) and (options['HB'] is not None):
-            HB = np.zeros((NC, 2), dtype=np.int)
+            HB = np.zeros((NC, 2), dtype=np.int_)
             HB[:, 0] = np.arange(NC)
             HB[:, 1] = np.arange(NC)
             options['HB'] = HB
@@ -1793,11 +1793,11 @@ class HalfEdgeMesh2d(Mesh, Plotable):
             isMarkedHEdge = np.r_[isMarkedHEdge, np.zeros(NE1+NE2*2, dtype=np.bool_)]
 
             #修改半边颜色
-            color = np.r_[color, np.zeros(NE1, dtype=np.int)]
+            color = np.r_[color, np.zeros(NE1, dtype=np.int_)]
             color[flag]=0
             color[halfedge[flag, 2]] = 1
             color[halfedge[halfedge[flag, 3], 3]] = 1
-            color = np.r_[color, np.zeros(NE2*2, dtype=np.int)]
+            color = np.r_[color, np.zeros(NE2*2, dtype=np.int_)]
             self.halfedgedata['color'] = color
 
             self._refine_tri_cell_(isNewCell, flag, options=options)

--- a/fealpy/vem/__init__.py
+++ b/fealpy/vem/__init__.py
@@ -17,3 +17,5 @@ from .scalar_source_integrator import NonConformingVEMScalarSourceIntegrator2d
 from .bilinear_form import BilinearForm
 from .linear_form import LinearForm
 from .estimator import PoissonCVEMEstimator
+
+from .poisson_vem_adaptive_solver import PoissonACVEMSolver

--- a/fealpy/vem/poisson_vem_adaptive_solver.py
+++ b/fealpy/vem/poisson_vem_adaptive_solver.py
@@ -1,22 +1,68 @@
 import numpy as np
+from scipy.sparse.linalg import spsolve
+import matplotlib.pyplot as plt
 
+# 网格
+from ..mesh import PolygonMesh
+from ..mesh.halfedge_mesh import HalfEdgeMesh2d
+
+# 协调有限元空间
+from ..functionspace import ConformingScalarVESpace2d
+
+# 积分子
+from fealpy.vem import ScaledMonomialSpaceMassIntegrator2d
+from fealpy.vem import ConformingVEMDoFIntegrator2d
+from fealpy.vem import ConformingScalarVEMH1Projector2d
+from fealpy.vem import ConformingScalarVEML2Projector2d
+from fealpy.vem import ConformingScalarVEMLaplaceIntegrator2d
+from fealpy.vem import ConformingVEMScalarSourceIntegrator2d
+from fealpy.vem import PoissonCVEMEstimator
+
+# 双线性型
+from fealpy.vem import BilinearForm
+
+# 线性型
+from fealpy.vem import LinearForm
+
+# 边界条件
+from ..boundarycondition import DirichletBC
+
+from ..mesh.adaptive_tools import mark
+from ..tools.show import showmultirate
 
 class PoissonACVEMSolver:
-
     def __init__(self, pde, mesh, p=1):
-        self.mesh = mesh
+        '''
+        初始化 PoissonACVEMSolver 对象
+
+        Parameters:
+            pde: 模型问题
+            mesh: 初始网格
+            p: 网格阶数
+        '''
+        self.mesh = PolygonMesh.from_mesh(mesh)
+        self.Hmesh = HalfEdgeMesh2d.from_mesh(mesh)
         self.pde = pde
         self.p = p
 
+        self.NDof = []
+        self._NF = 0 # 函数solve调用计数器
 
-    def solve(self):
-
+    def solve(self,save_data=False,filepath='./'):
+        '''
+        组装矩阵与右端项，求解方程
+        Parameters:
+            save_data: 是否保存数据，默认为 False
+            filepath: 数据保存路径，默认为当前目录下
+        Returns:
+            uh: 数值解
+        '''
         mesh = self.mesh
         pde = self.pde
         space = ConformingScalarVESpace2d(mesh, p=self.p)
         uh = space.function()
-        
-        NDof[i] = space.number_of_global_dofs()
+
+        self.NDof.append(space.number_of_global_dofs())
       
         #组装刚度矩阵 A 
         m = ScaledMonomialSpaceMassIntegrator2d()
@@ -48,27 +94,62 @@ class PoissonACVEMSolver:
         A, F = bc.apply(A, F, uh)
 
         uh[:] = spsolve(A, F)
+        if save_data:
+            np.savez(filepath+f"equ{self._NF}.npz",A=A,F=F,uh=uh)
 
         uh.M = M
         uh.PI1 = PI1
-
+        self._NF += 1
         return uh
 
-    def adaptive_solve(self, maxit=40, theta=0.2):
+    def adaptive_solve(self, maxit=40, theta=1.0, save_data=False,meshfilepath="./",equfilepath="./"):
+        '''
+        自适应求解
+
+        Parameters:
+            maxit: 最大迭代次数，默认为 40
+            theta: 标记策略参数，默认为 1.0
+            save_data: 是否保存数据，默认为 False
+            meshfilepath: 网格数据保存路径，默认为当前目录下
+            equfilepath: 求解方程数据保存路径，默认为当前目录下
+
+        Returns:
+            None
+        '''
+        errorType = ['$|| u - \Pi u_h||_{\Omega,0}$',
+         '$||\\nabla u - \Pi \\nabla u_h||_{\Omega, 0}$',
+         '$\eta $']
+        errorMatrix = np.zeros((3,maxit),dtype=np.float64)
+        Hmesh = self.Hmesh
+        pde = self.pde
         for i in range(maxit):
-            uh = self.solve()
+            uh = self.solve(save_data=save_data,filepath=equfilepath)
             space = uh.space
             sh = space.project_to_smspace(uh, uh.PI1)
 
             estimator = PoissonCVEMEstimator(space, uh.M, uh.PI1)
             eta = estimator.residual_estimate(uh, pde.source)
             
-            errorMatrix[0, i] = mesh.error(pde.solution, sh.value)
-            errorMatrix[1, i] = mesh.error(pde.gradient, sh.grad_value)
+            errorMatrix[0, i] = self.mesh.error(pde.solution, sh.value)
+            errorMatrix[1, i] = self.mesh.error(pde.gradient, sh.grad_value)
 
             errorMatrix[2, i] = np.sqrt(np.sum(eta))
-            options = Hmesh.adaptive_options(HB=None)
+            #isMarkedCell = mark(eta, theta=theta)
+            #Hmesh.adaptive_refine(isMarkedCell, method='nvb')
+            options = Hmesh.adaptive_options(theta=theta,HB=None)
             Hmesh.adaptive(eta, options)
-            newcell, cellocation = Hmesh.entity('cell')
+            newcell = Hmesh.entity('cell')
             newnode = Hmesh.entity("node")[:]
-            self.mesh = PolygonMesh(newnode, newcell, cellocation)
+            self.mesh = PolygonMesh(newnode, newcell)
+            # 保存网格数据
+            if save_data:
+                cell = np.concatenate(newcell)
+                cellLocation = self.mesh.ds.cellLocation
+                np.savez(meshfilepath+f"mesh{i+1}.npz",node=newnode,cell=cell,cellLocation=cellLocation)
+        showmultirate(plt, maxit-4, np.array(self.NDof), errorMatrix, errorType, propsize=20, lw=2, ms=4)
+        print(errorMatrix)
+        plt.show()
+        fig1 = plt.figure()
+        axes  = fig1.gca()
+        self.mesh.add_plot(axes)
+        plt.show()

--- a/test/vem/test_poisson_acvem_adaptive.py
+++ b/test/vem/test_poisson_acvem_adaptive.py
@@ -1,0 +1,28 @@
+import numpy as np
+from fealpy.pde.poisson_2d import LShapeRSinData
+from fealpy.vem import PoissonACVEMSolver
+
+from fealpy.mesh import PolygonMesh
+import matplotlib.pyplot as plt
+
+meshfilepath = './data/mesh/'# 需要创建相应的文件夹
+equfilepath = './data/equ/' # # 需要创建相应的文件夹
+
+pde = LShapeRSinData()
+mesh = pde.init_mesh(n=1,meshtype='quad')
+solver = PoissonACVEMSolver(pde,mesh)
+solver.adaptive_solve(maxit=4,save_data=True,meshfilepath=meshfilepath,equfilepath=equfilepath)
+
+# 读取保存的数据
+data = np.load(meshfilepath+"mesh1.npz")
+node = data['node']
+cell = data['cell']
+cellLocation = data['cellLocation']
+
+# 重新生成网格，数据可以使用
+mesh = PolygonMesh(node,cell,cellLocation)
+
+fig = plt.figure()
+axes = fig.gca()
+mesh.add_plot(axes)
+plt.show()


### PR DESCRIPTION
1. 添加 poisson_vem_adaptive_solver.py，输入pde模型与初始网格，可以进行虚单元自适应计算，并有保存网格数据与计算中方程的数据
2. 在test/vem下添加test_poisson_acvem_adaptive.py，对poisson_vem_adaptive_solver.py
3. 修改了一些halfedge_mesh的bug