### PR TITLE
优化边界元算例代码，实现 uniform_mesh_3d 相关方法

### DIFF
--- a/example/bem/laplace_constant_mixed_2d_forloop.py
+++ b/example/bem/laplace_constant_mixed_2d_forloop.py
@@ -6,11 +6,11 @@ from fealpy.mesh import TriangleMesh
 
 # 模型初始化，可尝试三种边界条件，默认是混合边界条件
 # 混合边界模型
-pde = LaplaceBemModelMixedBC2d()
+# pde = LaplaceBemModelMixedBC2d()
 # Dirichlet 边界模型
 # pde = LaplaceBemModelDirichletBC2d()
 # Neumann 边界模型
-# pde = LaplaceBemModelNeumannBC2d()
+pde = LaplaceBemModelNeumannBC2d()
 
 # # 网格初始化
 box = [0, 1, 0, 1]
@@ -37,63 +37,63 @@ for k in range(maxite):
 
     # 边界信息
     bdNode_idx = mesh.ds.boundary_node_index()
-    bdEdge = mesh.ds.boundary_edge()
-    bdEdge_flag = mesh.ds.boundary_edge_flag()
-    bdEdge_idx = mesh.ds.boundary_edge_index()
-    bdEdge_measure = mesh.entity_measure('edge', index=bdEdge_idx)
+    bd_face = mesh.ds.boundary_face()
+    bd_face_flag = mesh.ds.boundary_face_flag()
+    bd_face_idx = mesh.ds.boundary_face_index()
+    bd_face_measure = mesh.entity_measure('face', index=bd_face_idx)
 
     # 计算离散边界中点坐标与函数值
-    Pj = mesh.entity_barycenter('edge')[bdEdge_flag]
-    Pj_val = (bd_val[bdEdge[:, 0]] + bd_val[bdEdge[:, 1]]) / 2
+    Pj = mesh.entity_barycenter('edge')[bd_face_flag]
+    Pj_val = (bd_val[bd_face[:, 0]] + bd_val[bd_face[:, 1]]) / 2
 
     # 计算离散边界中点法向导数值
-    M = np.zeros((bdEdge.shape[0], bdEdge.shape[0]), dtype=float)
-    H = np.zeros_like(M)
+    G = np.zeros((bd_face.shape[0], bd_face.shape[0]), dtype=float)
+    H = np.zeros_like(G)
     # Gauss 积分点重心坐标及其权重
     qf = mesh.integrator(q=2, etype='edge')
     bcs, ws = qf.get_quadrature_points_and_weights()
     # 计算相关矩阵元素值
-    for i in range(bdEdge.shape[0]):
-        xi = (node[bdEdge[i, 1]] + node[bdEdge[i, 0]]) / 2
-        x1 = node[bdEdge[:, 0]]
-        x2 = node[bdEdge[:, 1]]
-        xj = (x1 + x2) / 2
+    x1 = node[bd_face[:, 0]]
+    x2 = node[bd_face[:, 1]]
+    xj = (x1 + x2) / 2
+    ps = np.einsum('qj, ejd->eqd', bcs, node[bd_face])
+    for i in range(bd_face.shape[0]):
+        xi = (node[bd_face[i, 1]] + node[bd_face[i, 0]]) / 2
         c = np.sign((x1[:, 0] - xi[0]) * (x2[:, 1] - xi[1]) - (x2[:, 0] - xi[0]) * (x1[:, 1] - xi[1]))
-        hij = c * np.abs((xi[0] - xj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - xj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bdEdge_measure
-        ps = np.einsum('qj, ejd->eqd', bcs, node[bdEdge])
+        hij = c * np.abs((xi[0] - xj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - xj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bd_face_measure
         rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))
-        H[..., i, :] = np.einsum('e,e,q,eq->e', -bdEdge_measure, hij, ws, 1 / rij ** 2)/2/np.pi
-        M[..., i, :] = bdEdge_measure / 2 / np.pi * np.einsum('q, eq ->e', ws, np.log(1 / rij))
+        H[..., i, :] = np.einsum('e,e,q,eq->e', -bd_face_measure, hij, ws, 1 / rij ** 2) / 2 / np.pi
+        G[..., i, :] = bd_face_measure / 2 / np.pi * np.einsum('q, eq ->e', ws, np.log(1 / rij))
 
     np.fill_diagonal(H, 0.5)
-    np.fill_diagonal(M, (bdEdge_measure * (np.log(2 / bdEdge_measure) + 1) / np.pi / 2))
+    np.fill_diagonal(G, (bd_face_measure * (np.log(2 / bd_face_measure) + 1) / np.pi / 2))
 
 
     is_dirichlet_node = pde.is_dirichlet_boundary(node)
     is_neumann_node = pde.is_neumann_boundary(node)
     # Dirichlet 边和 Neumann 边在全部边界边上的局部索引
-    dirichlet_dbEdge_idx = np.arange(bdEdge.shape[0])[(is_dirichlet_node[bdEdge[:, 0]] & is_dirichlet_node[bdEdge[:, 1]])]
-    neumann_dbEdge_idx = np.arange(bdEdge.shape[0])[(is_neumann_node[bdEdge[:, 0]] & is_neumann_node[bdEdge[:, 1]])]
+    dirichlet_dbEdge_idx = np.arange(bd_face.shape[0])[(is_dirichlet_node[bd_face[:, 0]] & is_dirichlet_node[bd_face[:, 1]])]
+    neumann_dbEdge_idx = np.arange(bd_face.shape[0])[(is_neumann_node[bd_face[:, 0]] & is_neumann_node[bd_face[:, 1]])]
 
-    bd_u_val = np.zeros(bdEdge.shape[0])
-    bd_un_val = np.zeros(bdEdge.shape[0])
-    dirichlet_node = (node[bdEdge[dirichlet_dbEdge_idx][:, 0]]+node[bdEdge[dirichlet_dbEdge_idx][:, 1]])/2
-    neumann_node = (node[bdEdge[neumann_dbEdge_idx][:, 0]]+node[bdEdge[neumann_dbEdge_idx][:, 1]])/2
-    n = mesh.face_unit_normal(bdEdge_idx)[neumann_dbEdge_idx]
+    bd_u_val = np.zeros(bd_face.shape[0])
+    bd_un_val = np.zeros(bd_face.shape[0])
+    dirichlet_node = (node[bd_face[dirichlet_dbEdge_idx][:, 0]] + node[bd_face[dirichlet_dbEdge_idx][:, 1]]) / 2
+    neumann_node = (node[bd_face[neumann_dbEdge_idx][:, 0]] + node[bd_face[neumann_dbEdge_idx][:, 1]]) / 2
+    n = mesh.face_unit_normal(bd_face_idx)[neumann_dbEdge_idx]
 
-    temp_A = np.zeros_like(M)
-    temp_X = np.zeros_like(M)
+    temp_A = np.zeros_like(G)
+    temp_X = np.zeros_like(G)
     temp_F = np.zeros(Pj.shape[0])
 
-    temp_A[:, dirichlet_dbEdge_idx] = -M[:, dirichlet_dbEdge_idx]
+    temp_A[:, dirichlet_dbEdge_idx] = -G[:, dirichlet_dbEdge_idx]
     temp_A[:, neumann_dbEdge_idx] = H[:, neumann_dbEdge_idx]
     temp_X[:, dirichlet_dbEdge_idx] = -H[:, dirichlet_dbEdge_idx]
-    temp_X[:, neumann_dbEdge_idx] = M[:, neumann_dbEdge_idx]
+    temp_X[:, neumann_dbEdge_idx] = G[:, neumann_dbEdge_idx]
     temp_F[dirichlet_dbEdge_idx] = pde.dirichlet(dirichlet_node)
     temp_F[neumann_dbEdge_idx] = pde.neumann(neumann_node, n)
 
-    if neumann_dbEdge_idx.shape[0] == bdEdge.shape[0]:
-        CC = bdEdge_measure[np.newaxis, :]
+    if neumann_dbEdge_idx.shape[0] == bd_face.shape[0]:
+        CC = bd_face_measure[np.newaxis, :]
         temp_Matrix = np.block([[temp_A, CC.T], [CC, 0]])
         temp_result = np.linalg.solve(temp_Matrix, np.block([temp_X @ temp_F, 0]))
     else:
@@ -113,19 +113,17 @@ for k in range(maxite):
     # 计算内部节点相关矩阵元素值
     for i in range(internal_node.shape[0]):
         Hi = 0
-        Mi = 0
+        Gi = 0
         xi = internal_node[i]
-        x1 = node[bdEdge[:, 0]]
-        x2 = node[bdEdge[:, 1]]
-        xj = (x1 + x2) / 2
+
         c = np.sign((x1[:, 0] - xi[0]) * (x2[:, 1] - xi[1]) - (x2[:, 0] - xi[0]) * (x1[:, 1] - xi[1]))
         hij = c * np.abs(
-            (xi[0] - xj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - xj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bdEdge_measure
-        ps = np.einsum('qj, ejd->eqd', bcs, node[bdEdge])
+            (xi[0] - xj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - xj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bd_face_measure
+
         rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))
-        Hi = np.einsum('e...,e,e,q,eq->...', bd_u_val, -bdEdge_measure, hij, ws, 1 / rij ** 2) / 2 / np.pi
-        Mi = np.einsum('e,e...,q,eq->...', bd_un_val, bdEdge_measure, ws, np.log(1 / rij)) / 2 / np.pi
-        uh[interNode_idx[i]] = Mi - Hi
+        Hi = np.einsum('e...,e,e,q,eq->...', bd_u_val, -bd_face_measure, hij, ws, 1 / rij ** 2) / 2 / np.pi
+        Gi = np.einsum('e,e...,q,eq->...', bd_un_val, bd_face_measure, ws, np.log(1 / rij)) / 2 / np.pi
+        uh[interNode_idx[i]] = Gi - Hi
 
     real_solution = pde.solution(node)
     h = np.max(mesh.entity_measure('cell'))

--- a/example/bem/poisson_constant_dirichlet_2d_forloop.py
+++ b/example/bem/poisson_constant_dirichlet_2d_forloop.py
@@ -49,9 +49,12 @@ for k in range(maxite):
     # 构建边界 Gauss 积分子，获取积分点重心坐标及其权重
     face_qf = mesh.integrator(q=2, etype='edge')  # 定义积分对象
     face_bcs, face_ws = face_qf.get_quadrature_points_and_weights()  # 返回积分点在区域内的重心坐标和权重
+    # 计算积分点笛卡尔坐标，q 为每个边界上积分点，j 为边界端点，f 为边界，d 为空间维数
+    face_ps = np.einsum('qj, fjd->fqd', face_bcs, Node[bd_face])
     # 单元 Gauss 积分子
     cell_qf = mesh.integrator(q=3, etype='cell')
     cell_bcs, cell_ws = cell_qf.get_quadrature_points_and_weights()
+    cell_ps = np.einsum('qj, ejd->eqd', cell_bcs, Node[Cell])  # 求高斯积分点
 
     x1 = Node[bd_face[:, 0]]
     x2 = Node[bd_face[:, 1]]
@@ -62,14 +65,12 @@ for k in range(maxite):
         # np.sign如果元素为正数，则返回1,如果元素为负数，则返回-1如果元素为0，则返回0
         hij = c * np.abs(
             (xi[0] - Pj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - Pj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bd_face_measure
-        # 计算积分点笛卡尔坐标，q 为每个边界上积分点，j 为边界端点，f 为边界，d 为空间维数
-        ps = np.einsum('qj, fjd->fqd', face_bcs, Node[bd_face])
-        rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))
+
+        rij = np.sqrt(np.sum((face_ps - xi) ** 2, axis=-1))
         H[..., i, :] = np.einsum('f,f,q,fq->f', -bd_face_measure, hij, face_ws, 1 / rij ** 2) / 2 / np.pi
         G[..., i, :] = bd_face_measure / 2 / np.pi * np.einsum('q, fq ->f', face_ws, np.log(1 / rij))
 
         # 源项数值积分
-        cell_ps = np.einsum('qj, ejd->eqd', cell_bcs, Node[Cell])  # 求高斯积分点
         cell_rij = np.sqrt(np.sum((cell_ps - xi) ** 2, axis=-1))  # 求解任意两点距离
         b = pde.source(cell_ps)
         B[i] = np.einsum('e,b,eb,eb->', cell_measure, cell_ws, b, np.log(1 / cell_rij)) / np.pi / 2
@@ -92,16 +93,13 @@ for k in range(maxite):
         c = np.sign((x1[:, 0] - xi[0]) * (x2[:, 1] - xi[1]) - (x2[:, 0] - xi[0]) * (x1[:, 1] - xi[1]))
         hij = c * np.abs(
             (xi[0] - Pj[:, 0]) * (x2[:, 1] - x1[:, 1]) - (xi[1] - Pj[:, 1]) * (x2[:, 0] - x1[:, 0])) / bd_face_measure
-        ps = np.einsum('qj, ejd->eqd', face_bcs, Node[bd_face])
 
-        rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))
+        rij = np.sqrt(np.sum((face_ps - xi) ** 2, axis=-1))
         Hi = np.einsum('f...,f,f,q,fq->...', bd_u_val, -bd_face_measure, hij, face_ws, 1 / rij ** 2) / 2 / np.pi
         Mi = np.einsum('f,f...,q,fq->...', bd_un_val, bd_face_measure, face_ws, np.log(1 / rij)) / 2 / np.pi
 
-        cell_ps = np.einsum('qj, fjd->fqd', cell_bcs, Node[Cell])  # 求高斯积分点
-        cell_rij = np.sqrt(np.sum((cell_ps - xi) ** 2, axis=-1))  # 求解任意两点距离
+        cell_rij = np.sqrt(np.sum((cell_ps - xi) ** 2, axis=-1))
         b = -2 * np.pi ** 2 * np.sin(np.pi * cell_ps[..., 0]) * np.sin(np.pi * cell_ps[..., 1])
-        # s=[(xk[0]-xi1[0])*(xi1[1]-xj1[1])-(xk[1]-xj1[1])*(xi1[0]-xk[0])]
         Bi = np.einsum('f,q,fq,fq->', cell_measure, cell_ws, b, np.log(1 / cell_rij)) / np.pi / 2
         uh[interNode_idx[i]] = Mi - Hi - Bi  # 近似解在内部节点的函数值
 

--- a/example/bem/poisson_constant_dirichlet_3d_forloop.py
+++ b/example/bem/poisson_constant_dirichlet_3d_forloop.py
@@ -8,138 +8,82 @@ pde = PoissonModelConstantDirichletBC3d()
 nx = 5
 ny = 5
 nz = 5
-# 第一个问题：边界节点和边界面不同数，在用线性方程求解时会出现零矩阵
-# 第三个问题：J矩阵以及G的对角元素待求，J=1/4面面积
-# 根据网格剖分数计算网格节点间距
+
 hx = (1 - 0) / nx
 hy = (1 - 0) / ny
 hz = (1 - 0) / nz
 
-maxite = 2
+maxite = 3
 
 errorMatrix = np.zeros(maxite)
-# mesh = UniformMesh3d((0, 10, 0, 10, 0, 10))
 mesh = UniformMesh3d((0, nx, 0, ny, 0, nz), h=(hx, hy, hz), origin=(0, 0, 0))  #
 
 for k in range(maxite):
-    # 给出各元素数量
+    # 获取网格信息
     NN = mesh.number_of_nodes()
     NC = mesh.number_of_cells()
     NE = mesh.number_of_edges()
     NF = mesh.number_of_faces()
 
-    # 获取坐标
     Node = mesh.entity('node')
     Cell = mesh.entity('cell')
     Edge = mesh.entity('edge')
     Face = mesh.entity('face')
 
     # 获取边界信息
-    bdCell = mesh.ds.boundary_cell()  # 给出组成单元的节点全局编号
-    bdNode = mesh.ds.boundary_node_index()
+    bd_node_idx = mesh.ds.boundary_node_index()
+    bd_face = mesh.ds.boundary_face()
+    bd_face_index = mesh.ds.boundary_face_index()
+    bd_face_flag = mesh.ds.boundary_face_flag()
 
-    bdCell_idx = mesh.ds.boundary_cell_index()  # 边界单元个数
-    bdEdge = mesh.ds.boundary_edge()
-    bdface = mesh.ds.boundary_face()
-    bdEdge_idx = mesh.ds.boundary_edge_index()
-    # print("1",bdEdge_idx[0])
-    # print("2",bdNode.shape[0])
-    bdface_flag = mesh.ds.boundary_face_flag()
-    # 计算函数值
-    bd_val = pde.dirichlet(Node)  # 求精确解
-    uh = np.zeros_like(bd_val)
-
-    # 计算每个体单元的面积
-    index = np.s_[:]  # 表示获取所有的元素索引
-    v1 = Node[Cell[index, 1], :] - Node[Cell[index, 0], :]
-    v2 = Node[Cell[index, 2], :] - Node[Cell[index, 1], :]
-    v3 = Node[Cell[index, 3], :] - Node[Cell[index, 2], :]
-    v4 = Node[Cell[index, 3], :] - Node[Cell[index, 0], :]
-    h1 = Node[Cell[index, 4], :] - Node[Cell[index, 0], :]
-    h2 = Node[Cell[index, 5], :] - Node[Cell[index, 1], :]
-    h3 = Node[Cell[index, 6], :] - Node[Cell[index, 2], :]
-    h4 = Node[Cell[index, 7], :] - Node[Cell[index, 3], :]
-    tsa1 = Node[Cell[index, 5], :] - Node[Cell[index, 4], :]
-    tsa2 = Node[Cell[index, 6], :] - Node[Cell[index, 5], :]
-    ba = np.sqrt(np.square(np.cross(v2, -v1)).sum(axis=1))  # 这个np.square是计算向量模长
-    sa = np.sqrt(np.square(np.cross(h1, -v1)).sum(axis=1))
-    sa2 = np.sqrt(np.square(np.cross(h2, -v2)).sum(axis=1))
-    sa3 = np.sqrt(np.square(np.cross(h3, -v3)).sum(axis=1))
-    sa4 = np.sqrt(np.square(np.cross(h4, -v4)).sum(axis=1))
-    ta = np.sqrt(np.square(np.cross(tsa2, -tsa1)).sum(axis=1))
-    v = np.sqrt(np.square(v1).sum(axis=1)) ** 3  # 正六面体体单元体积(125.3)
-
-    bdCell_measure = ba + ta + sa + sa2 + sa3 + sa4  # 体单元面积
-
-    # 求单元边长
-    bdEdge_measure = mesh.entity_measure('edge')
-    bdFace_measure = mesh.entity_measure('face')
-    # 求面单元面积
-    s1 = Node[bdface[index, 1]] - Node[bdface[index, 0]]
-    s2 = Node[bdface[index, 3]] - Node[bdface[index, 0]]
-    s = np.sqrt(np.square(np.cross(s2, -s1)).sum(axis=1))  # 面单元面积
-    s3 = Node[Face[index, 1]] - Node[Face[index, 0]]
-    s4 = Node[Face[index, 3]] - Node[Face[index, 0]]
-    s2 = np.sqrt(np.square(np.cross(s4, -s3)).sum(axis=1))
     # 求近视解与真解
     bd_val = pde.dirichlet(Node)
     uh = np.zeros_like(bd_val)
 
+    # 边界节点坐标
+    Pj = mesh.entity_barycenter('face')[bd_face_flag]
 
-    Pj = mesh.entity_barycenter('face')[bdface_flag]  # 计算边界面单元重心坐标
-    # (150,3)
-    # Pj1=mesh.entity_barycenter('edge')
-    # 这里给定矩阵大小
-    G = np.zeros((bdface.shape[0], bdface.shape[0]), dtype=float)
+    G = np.zeros((bd_face.shape[0], bd_face.shape[0]), dtype=float)
     H = np.zeros_like(G)
-    B = np.zeros(bdface.shape[0])
+    B = np.zeros(bd_face.shape[0])
+
     # Gauss 积分点重心坐标及其权重
-    qs = mesh.integrator(q=2, etype=2)
-    bcs, ws = qs.get_quadrature_points_and_weights()  # ws(8,),bcs(3,2,2)
-    # ps = mesh.bc_to_point(bcs)#bcs是0-1区间内的高斯坐标即重心坐标，此时通过重心坐标和网格节点求解边界点坐标
-    # ps维数（NQ,NC，3），NQ为积分点个数，即每个积分点所对应的笛卡尔坐标
-    gs = mesh.integrator(q=3)
-    bcs1, ws1 = gs.get_quadrature_points_and_weights()  # ws1(27,)
-    ps1 = mesh.bc_to_point(bcs1)
+    face_qs = mesh.integrator(q=2, etype=2)
+    face_bcs, face_ws = face_qs.get_quadrature_points_and_weights()
+    face_ps = mesh.bc_to_point(face_bcs, bd_face_index)
 
-    bc0 = bcs[0].reshape(-1, 2)  # (NQ0, 2)
-    bc1 = bcs[1].reshape(-1, 2)  # (NQ1, 2)
-    bc = np.einsum('im, jn->ijmn', bc0, bc1).reshape(-1, 4)  # (NQ0, NQ1, 2, 2)
+    cell_qs = mesh.integrator(q=3)
+    cell_bcs, cell_ws = cell_qs.get_quadrature_points_and_weights()
+    cell_ps = mesh.bc_to_point(cell_bcs)
 
-    # node[cell].shape == (NC, 4, 2)
-    # bc.shape == (NQ, 4)
-    ps = np.einsum('...j, cjk->...ck', bc, Node[bdface[:]])  # (4,150,3)(NQ, NC, 2),面单元情况下每个积分点对应的笛卡尔坐标
-    J = s
-    for i in range(bdface.shape[0]):
-        # 取每个平面的重心点
-        xi = Pj[i, :]  # (3,)
-        e1 = Node[bdface[:, 1]] - Node[bdface[:, 0]]
-        e2 = Node[bdface[:, 3]] - Node[bdface[:, 0]]
-        x1 = Node[bdface[:, 1]]  # （600，3）
-        n = np.cross(e2, e1)  # （150，3)
-        hij = np.einsum('ei, ei -> e', n, x1-xi) / np.linalg.norm(n, axis=-1)
-        # ps1=np.einsum('qji,edq->ejq',bcs,Node[bdface])#(150,2,3)
+    # 计算边界面外法向量，面积
+    n = mesh.face_normal(index=bd_face_index)
+    s = mesh.entity_measure('face', bd_face_index)
+    # 计算体单元体积
+    v = mesh.entity_measure('cell')
 
-        rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))  # (4,150)
-        rij1 = np.sqrt(np.sum((ps1 - xi) ** 2, axis=-1))  # (27,125)
-        b = pde.source(ps1)  # (27,125)
-        # B计算有误
-        B[i] = np.einsum("k,mk,m,mk->", v, 1 / rij1, ws1, b) / 4 / np.pi
-        # H[..., i, :] = -np.einsum('ij,q,qi,i->i', hij, ws, 1 / rij, J) / np.pi
-        # G[..., i, :] = np.einsum('q,qi,i->i', ws, 1 / rij, J) / np.pi
-        H[..., i, :] = -np.einsum('i,q,qi,i->i', hij, ws, 1 / rij**3, J) / np.pi / 4
-        G[..., i, :] = np.einsum('q,qi,i->i', ws, 1 / rij, J) / np.pi / 4
+    x1 = Node[bd_face[:, 1]]
+    b = pde.source(cell_ps)
+    for i in range(bd_face.shape[0]):
+        xi = Pj[i, :]
+        hij = np.einsum('fi, fi -> f', n, x1-xi) / np.linalg.norm(n, axis=-1)
+
+        rij = np.sqrt(np.sum((face_ps - xi) ** 2, axis=-1))
+        rij1 = np.sqrt(np.sum((cell_ps - xi) ** 2, axis=-1))
+
+        H[..., i, :] = -np.einsum('f,q,qf,f->f', hij, face_ws, 1 / rij ** 3, s) / np.pi / 4
+        G[..., i, :] = np.einsum('q,qf,f->f', face_ws, 1 / rij, s) / np.pi / 4
+        B[i] = np.einsum("f,if,i,if->", v, 1 / rij1, cell_ws, b) / 4 / np.pi
 
     # 计算给定矩阵主对角线元素
     np.fill_diagonal(H, 0.5)
-    # np.fill_diagonal(G, J)
 
     bd_u_val = pde.dirichlet(Pj)
     bd_un_val = np.linalg.solve(G, H @ bd_u_val + B)
 
     # 内部节点处理
-    internal_node = Node[~mesh.ds.boundary_node_flag()]  # 内部节点坐标这里意思是除去边界节点
-    uh[bdNode] = bd_val[bdNode]  # 将每条边的全局编号处的精确解赋值给近视解
+    internal_node = Node[~mesh.ds.boundary_node_flag()]
+    uh[bd_node_idx] = bd_val[bd_node_idx]
     interNode_idx = np.arange(NN)[~mesh.ds.boundary_node_flag()]
 
     # 计算内部节点相关矩阵元素值
@@ -147,22 +91,18 @@ for k in range(maxite):
         Hi = 0
         Mi = 0
         xi = internal_node[i]
-        e1 = Node[bdface[:, 1]] - Node[bdface[:, 0]]
-        e2 = Node[bdface[:, 3]] - Node[bdface[:, 0]]
-        x1 = Node[bdface[:, 1]]  # （150，3）
-        n = np.cross(e2, e1)  # （150，3）#边界面的法向量
-        hij = np.einsum('ei, ei -> e', n, x1-xi) / np.linalg.norm(n, axis=-1)
-        rij = np.sqrt(np.sum((ps - xi) ** 2, axis=-1))
-        rij1 = np.sqrt(np.sum((ps1 - xi) ** 2, axis=-1))
-        Hi = -np.einsum('i,i,q,qi,i->...', bd_u_val, hij, ws, 1 / rij ** 3, J) / np.pi / 4
-        Mi = np.einsum('i,q,qi,i->...', bd_un_val, ws, 1 / rij, J) / np.pi / 4
-        Bi = np.einsum("k,mk,m,mk->", v, 1 / rij1, ws1, b) / 4 / np.pi
+        hij = np.einsum('fi, fi -> f', n, x1-xi) / np.linalg.norm(n, axis=-1)
+        rij = np.sqrt(np.sum((face_ps - xi) ** 2, axis=-1))
+        rij1 = np.sqrt(np.sum((cell_ps - xi) ** 2, axis=-1))
+        Hi = -np.einsum('f,f,q,qf,f->', bd_u_val, hij, face_ws, 1 / rij ** 3, s) / np.pi / 4
+        Mi = np.einsum('f,q,qf,f->', bd_un_val, face_ws, 1 / rij, s) / np.pi / 4
+        Bi = np.einsum("f,if,i,if->", v, 1 / rij1, cell_ws, b) / 4 / np.pi
         uh[interNode_idx[i]] = Mi - Hi - Bi
 
-    real_solution = pde.solution(Node)  # 真解值
-    h = np.max(v)  # 返回的是单元测度的最大值一般是体积或者大小
+    real_solution = pde.solution(Node)
+    h = np.max(v)
     errorMatrix[k] = np.sqrt(np.sum((uh - real_solution) ** 2) * h)
-    mesh.uniform_refine(1)  # 在这里将网格进行细化成更加小的网格，即类似之前椭圆方程步长减少
+    mesh.uniform_refine(1)
 print(f'迭代{maxite}次，结果如下：')
 print("误差：\n", errorMatrix)
 print('误差比：\n', errorMatrix[0:-1] / errorMatrix[1:])


### PR DESCRIPTION
新增：实现 uniform_mesh_3d.entity_measure、uniform_mesh_3d.face_normal、uniform_mesh_3d.face_unit_normal 方法；
修改：优化边界元算例代码；修改 uniform_mesh_3d.bc_to_point 方法，完善对面的处理。