### PR TITLE
update line_seach 

### DIFF
--- a/fealpy/opt/line_search.py
+++ b/fealpy/opt/line_search.py
@@ -140,8 +140,8 @@ def zoom(x: NDArray, s: Float, d: NDArray,
                 return alpha, xc, fc, gc
 
             if sc*(alpha_1 - alpha_0) >= 0:
-                alpha_0, alpha_1 = alpha, alpha_0
-                fl = fc
+                alpha_1 = alpha_0
+            alpha_0 = alpha
 
         iter_ += 1
     return alpha, xc, fc, gc


### PR DESCRIPTION
修改fealpy/opt/line_search 中zoom函数的bug。
1. 将alpha_0, alpha_1 = alpha, alpha_0 中的 alpha_1=alpha_0移到if语句外，否则如果两个if语句都不满足，alpha不会更新，会重复迭代直到满足迭代次数，影响结果和效率。
2. 去掉fl=fc。fl=fc对计算结果影响不大，但会增加主函数计算次数，影响效率