### PR TITLE
the Torch module update

### DIFF
--- a/fealpy/torch/fem/bilinear_form.py
+++ b/fealpy/torch/fem/bilinear_form.py
@@ -60,10 +60,7 @@ class BilinearForm(Form[_FS]):
             if not self.retain_ints:
                 bi.clear()
 
-        self._M = M.coalesce()
-        logger.info(f"Bilinear form matrix constructed, with shape {list(self._M.shape)}.")
-
-        return self._M
+        return M
 
     def _batch_assembly(self) -> Tensor:
         space = self.space
@@ -121,16 +118,18 @@ class BilinearForm(Form[_FS]):
             if not self.retain_ints:
                 bi.clear()
 
-        self._M = M.coalesce()
+        return M
+
+    def assembly(self, coalesce=True) -> Tensor:
+        r"""Assembly the bilinear form matrix. Returns COO Tensor of shape (gdof, gdof)."""
+        if self.batch_size == 0:
+            M = self._single_assembly()
+        elif self.batch_size > 0:
+            M = self._batch_assembly()
+        else:
+            raise ValueError("batch_size must be a non-negative integer.")
+
+        self._M = M.coalesce() if coalesce else M
         logger.info(f"Bilinear form matrix constructed, with shape {list(self._M.shape)}.")
 
         return self._M
-
-    def assembly(self) -> Tensor:
-        r"""Assembly the bilinear form matrix. Returns COO Tensor of shape (gdof, gdof)."""
-        if self.batch_size == 0:
-            return self._single_assembly()
-        elif self.batch_size > 0:
-            return self._batch_assembly()
-        else:
-            raise ValueError("batch_size must be a non-negative integer.")

--- a/fealpy/torch/fem/bilinear_form.py
+++ b/fealpy/torch/fem/bilinear_form.py
@@ -1,107 +1,135 @@
 
-from typing import Generic, TypeVar, Optional, List, overload, Sequence
+from typing import TypeVar, Optional, List
 
 import torch
 from torch import Tensor
 
 from .. import logger
 from ..functionspace.space import FunctionSpace
-from .form import IntegratorHandler
-from .integrator import DomainIntegrator as _DI
-from .integrator import BoundaryIntegrator as _BI
+from .form import IntegratorHandler, Form
 
 
 _FS = TypeVar('_FS', bound=FunctionSpace)
 
 
-class BilinearForm(Generic[_FS]):
+class BilinearForm(Form[_FS]):
     r"""@brief"""
-    def __init__(self, space: _FS, retain_ints: bool=False, batched: bool=False):
+    def __init__(self, space: _FS, retain_ints: bool=False, batch_size: int=0):
         self.space = space
         self.dintegrators: List[IntegratorHandler] = []
         self.bintegrators: List[IntegratorHandler] = []
         self._M: Optional[Tensor] = None
         self.retain_ints = retain_ints
-        self.batched = batched
+        self.batch_size = batch_size
 
-    def __len__(self) -> int:
-        return len(self.dintegrators) + len(self.bintegrators)
-
-    @overload
-    def add_domain_integrator(self, I: _DI[_FS]) -> IntegratorHandler: ...
-    @overload
-    def add_domain_integrator(self, I: Sequence[_DI[_FS]]) -> List[IntegratorHandler]: ...
-    @overload
-    def add_domain_integrator(self, *I: _DI[_FS]) -> List[IntegratorHandler]: ...
-    def add_domain_integrator(self, *I):
-        if len(I) == 1:
-            I = I[0]
-            if isinstance(I, Sequence):
-                handler = IntegratorHandler.build_list(I, form=self)
-                self.dintegrators.extend(handler)
-            else:
-                handler = IntegratorHandler(I, form=self)
-                self.dintegrators.append(handler)
-        elif len(I) >= 2:
-            handler = IntegratorHandler.build_list(I, form=self)
-            self.dintegrators.extend(handler)
-        else:
-            raise RuntimeError("add_domain_integrator() is called with no arguments.")
-
-        return handler
-
-    @overload
-    def add_boundary_integrator(self, I: _BI[_FS]) -> IntegratorHandler: ...
-    @overload
-    def add_boundary_integrator(self, I: Sequence[_BI[_FS]]) -> List[IntegratorHandler]: ...
-    @overload
-    def add_boundary_integrator(self, *I: _BI[_FS]) -> List[IntegratorHandler]: ...
-    def add_boundary_integrator(self, *I):
-        if len(I) == 1:
-            I = I[0]
-            if isinstance(I, Sequence):
-                handler = IntegratorHandler.build_list(I, form=self)
-                self.bintegrators.extend(handler)
-            else:
-                handler = IntegratorHandler(I, form=self)
-                self.bintegrators.append(handler)
-        elif len(I) >= 2:
-            handler = IntegratorHandler.build_list(I, form=self)
-            self.bintegrators.extend(handler)
-        else:
-            raise RuntimeError("add_boundary_integrator() is called with no arguments.")
-
-        return handler
-
-    def number_of_domain_integrators(self) -> int:
-        return len(self.dintegrators)
-
-    def number_of_boundary_integrators(self) -> int:
-        return len(self.bintegrators)
-
-    def assembly(self) -> Tensor:
-        r"""Assembly the bilinear form matrix. Returns COO Tensor of shape (gdof, gdof)."""
+    def _single_assembly(self) -> Tensor:
         space = self.space
+        device = space.device
         gdof = space.number_of_global_dofs()
         ldof = space.number_of_local_dofs()
         cell2dof = space.cell_to_dof()
-        cm = torch.zeros((gdof, gdof), dtype=space.dtype, device=space.device)
-        CM = self.dintegrators[0].assembly_cell_matrix(space)
+        NC = cell2dof.shape[0]
+        global_mat_shape = (gdof, gdof)
 
-        for idx, di in enumerate(self.dints):
-            if di is None:
-                self.render('d', idx)
+        if len(self.dintegrators) > 0:
+            local_mat_shape = (NC, ldof, ldof)
+            cell_mat = torch.zeros(local_mat_shape, dtype=space.ftype, device=device)
 
+            for i in range(len(self.dintegrators)):
+                di = self.dintegrators[i]
+                cell_mat = cell_mat + di.assembly_cell_matrix(space)
+                if not self.retain_ints:
+                    di.clear()
 
-        I = torch.broadcast_to(cell2dof[:, :, None], size=CM.shape)
-        J = torch.broadcast_to(cell2dof[:, None, :], size=CM.shape)
-        indices = torch.stack([I.ravel(), J.ravel()], dim=0)
-        M = torch.sparse_coo_tensor(indices, CM.ravel(), size=(gdof, gdof))
+            I = torch.broadcast_to(cell2dof[:, :, None], size=local_mat_shape)
+            J = torch.broadcast_to(cell2dof[:, None, :], size=local_mat_shape)
+            indices = torch.stack([I.ravel(), J.ravel()], dim=0)
+            M = torch.sparse_coo_tensor(indices, cell_mat.ravel(), size=global_mat_shape)
 
-        for bi in self.bintegrators:
+        else: # Create an empty global matrix if no domain integrators.
+            M = torch.sparse_coo_tensor(
+                torch.empty((2, 0), dtype=space.itype, device=device),
+                torch.empty((0,), dtype=space.ftype, device=device),
+                size=global_mat_shape
+            )
+
+        for i in range(len(self.bintegrators)):
+            bi = self.bintegrators[i]
             M = M + bi.assembly_face_matrix(space)
+            if not self.retain_ints:
+                bi.clear()
 
         self._M = M.coalesce()
         logger.info(f"Bilinear form matrix constructed, with shape {list(self._M.shape)}.")
 
         return self._M
+
+    def _batch_assembly(self) -> Tensor:
+        space = self.space
+        device = space.device
+        gdof = space.number_of_global_dofs()
+        ldof = space.number_of_local_dofs()
+        cell2dof = space.cell_to_dof()
+        NC = cell2dof.shape[0]
+        batch = self.batch_size
+        assert batch > 0
+        global_mat_shape = (gdof, gdof, batch)
+
+        if len(self.dintegrators) > 0:
+            local_mat_shape = (NC, ldof, ldof, batch)
+            cell_mat = torch.zeros(local_mat_shape, dtype=space.ftype, device=device)
+
+            for i in range(len(self.dintegrators)):
+                di = self.dintegrators[i]
+                new_mat = di.assembly_cell_matrix(space)
+
+                if new_mat.ndim == 3: # If the matrix does not have batch dimension
+                    new_mat = new_mat.unsqueeze(-1).expand(local_mat_shape)
+                # Then, the batch dimension should be exactly the same
+                cell_mat = cell_mat + new_mat
+
+                if not self.retain_ints:
+                    di.clear()
+
+            I = torch.broadcast_to(cell2dof[:, :, None], size=local_mat_shape)
+            J = torch.broadcast_to(cell2dof[:, None, :], size=local_mat_shape)
+            indices = torch.stack([I.ravel(), J.ravel()], dim=0)
+            cm_flatten = cell_mat.reshape(-1, batch)
+            M = torch.sparse_coo_tensor(indices, cm_flatten, size=global_mat_shape)
+
+        else: # Create an empty global matrix if no domain integrators.
+            M = torch.sparse_coo_tensor(
+                torch.empty((2, 0), dtype=space.itype, device=device),
+                torch.empty((0, batch), dtype=space.ftype, device=device),
+                size=global_mat_shape
+            )
+
+        for i in range(len(self.bintegrators)):
+            bi = self.bintegrators[i]
+            new_mat = bi.assembly_face_matrix(space)
+            value = new_mat.values()
+
+            if value.ndim == 1:
+                value = value[..., None].expand(-1, batch)
+                new_mat = torch.sparse_coo_tensor(
+                    new_mat.indices(), value, size=global_mat_shape
+                )
+
+            M = M + new_mat
+
+            if not self.retain_ints:
+                bi.clear()
+
+        self._M = M.coalesce()
+        logger.info(f"Bilinear form matrix constructed, with shape {list(self._M.shape)}.")
+
+        return self._M
+
+    def assembly(self) -> Tensor:
+        r"""Assembly the bilinear form matrix. Returns COO Tensor of shape (gdof, gdof)."""
+        if self.batch_size == 0:
+            return self._single_assembly()
+        elif self.batch_size > 0:
+            return self._batch_assembly()
+        else:
+            raise ValueError("batch_size must be a non-negative integer.")

--- a/fealpy/torch/fem/form.py
+++ b/fealpy/torch/fem/form.py
@@ -1,19 +1,26 @@
 
-from typing import Sequence
+from typing import Sequence, overload, List, Generic, TypeVar
 
 from torch import Tensor
 
-from .integrator import Integrator
+from .integrator import Integrator as _I
+from ..functionspace.space import FunctionSpace
+
+
+_FS = TypeVar('_FS', bound=FunctionSpace)
 
 
 class IntegratorHandler():
-    def __init__(self, integrator: Integrator, form=None) -> None:
+    def __init__(self, integrator: _I, form=None) -> None:
         self.integrator = integrator
         self.form = form
         self._value = None
 
+    def __getattr__(self, name: str):
+        return getattr(self.integrator, name)
+
     @classmethod
-    def build_list(cls, integrators: Sequence[Integrator], form=None):
+    def build_list(cls, integrators: Sequence[_I], form=None):
         return [cls(integrator, form) for integrator in integrators]
 
     @property
@@ -22,8 +29,63 @@ class IntegratorHandler():
             self._value = self.integrator.assembly()
         return self._value
 
-    def assembly(self) -> Tensor:
-        return self.integrator.assembly()
-
     def clear(self) -> None:
         self._value = None
+
+
+class Form(Generic[_FS]):
+    space: _FS
+    dintegrators: List[IntegratorHandler]
+    bintegrators: List[IntegratorHandler]
+
+    @overload
+    def add_domain_integrator(self, I: _I) -> IntegratorHandler: ...
+    @overload
+    def add_domain_integrator(self, I: Sequence[_I]) -> List[IntegratorHandler]: ...
+    @overload
+    def add_domain_integrator(self, *I: _I) -> List[IntegratorHandler]: ...
+    def add_domain_integrator(self, *I):
+        if len(I) == 1:
+            I = I[0]
+            if isinstance(I, Sequence):
+                handler = IntegratorHandler.build_list(I, form=self)
+                self.dintegrators.extend(handler)
+            else:
+                handler = IntegratorHandler(I, form=self)
+                self.dintegrators.append(handler)
+        elif len(I) >= 2:
+            handler = IntegratorHandler.build_list(I, form=self)
+            self.dintegrators.extend(handler)
+        else:
+            raise RuntimeError("add_domain_integrator() is called with no arguments.")
+
+        return handler
+
+    @overload
+    def add_boundary_integrator(self, I: _I) -> IntegratorHandler: ...
+    @overload
+    def add_boundary_integrator(self, I: Sequence[_I]) -> List[IntegratorHandler]: ...
+    @overload
+    def add_boundary_integrator(self, *I: _I) -> List[IntegratorHandler]: ...
+    def add_boundary_integrator(self, *I):
+        if len(I) == 1:
+            I = I[0]
+            if isinstance(I, Sequence):
+                handler = IntegratorHandler.build_list(I, form=self)
+                self.bintegrators.extend(handler)
+            else:
+                handler = IntegratorHandler(I, form=self)
+                self.bintegrators.append(handler)
+        elif len(I) >= 2:
+            handler = IntegratorHandler.build_list(I, form=self)
+            self.bintegrators.extend(handler)
+        else:
+            raise RuntimeError("add_boundary_integrator() is called with no arguments.")
+
+        return handler
+
+    def number_of_domain_integrators(self) -> int:
+        return len(self.dintegrators)
+
+    def number_of_boundary_integrators(self) -> int:
+        return len(self.bintegrators)

--- a/fealpy/torch/fem/form.py
+++ b/fealpy/torch/fem/form.py
@@ -10,79 +10,50 @@ from ..functionspace.space import FunctionSpace
 _FS = TypeVar('_FS', bound=FunctionSpace)
 
 
-class IntegratorHandler():
-    def __init__(self, integrator: _I, form=None) -> None:
-        self.integrator = integrator
-        self.form = form
-        self._value = None
-
-    def __getattr__(self, name: str):
-        return getattr(self.integrator, name)
-
-    @classmethod
-    def build_list(cls, integrators: Sequence[_I], form=None):
-        return [cls(integrator, form) for integrator in integrators]
-
-    @property
-    def value(self) -> Tensor:
-        if self._value is None:
-            self._value = self.integrator.assembly()
-        return self._value
-
-    def clear(self) -> None:
-        self._value = None
-
-
 class Form(Generic[_FS]):
     space: _FS
-    dintegrators: List[IntegratorHandler]
-    bintegrators: List[IntegratorHandler]
+    dintegrators: List[_I]
+    bintegrators: List[_I]
 
     @overload
-    def add_domain_integrator(self, I: _I) -> IntegratorHandler: ...
+    def add_domain_integrator(self, I: _I) -> _I: ...
     @overload
-    def add_domain_integrator(self, I: Sequence[_I]) -> List[IntegratorHandler]: ...
+    def add_domain_integrator(self, I: Sequence[_I]) -> List[_I]: ...
     @overload
-    def add_domain_integrator(self, *I: _I) -> List[IntegratorHandler]: ...
+    def add_domain_integrator(self, *I: _I) -> List[_I]: ...
     def add_domain_integrator(self, *I):
         if len(I) == 1:
             I = I[0]
             if isinstance(I, Sequence):
-                handler = IntegratorHandler.build_list(I, form=self)
-                self.dintegrators.extend(handler)
+                self.dintegrators.extend(I)
             else:
-                handler = IntegratorHandler(I, form=self)
-                self.dintegrators.append(handler)
+                self.dintegrators.append(I)
         elif len(I) >= 2:
-            handler = IntegratorHandler.build_list(I, form=self)
-            self.dintegrators.extend(handler)
+            self.dintegrators.extend(I)
         else:
             raise RuntimeError("add_domain_integrator() is called with no arguments.")
 
-        return handler
+        return I
 
     @overload
-    def add_boundary_integrator(self, I: _I) -> IntegratorHandler: ...
+    def add_boundary_integrator(self, I: _I) -> _I: ...
     @overload
-    def add_boundary_integrator(self, I: Sequence[_I]) -> List[IntegratorHandler]: ...
+    def add_boundary_integrator(self, I: Sequence[_I]) -> List[_I]: ...
     @overload
-    def add_boundary_integrator(self, *I: _I) -> List[IntegratorHandler]: ...
+    def add_boundary_integrator(self, *I: _I) -> List[_I]: ...
     def add_boundary_integrator(self, *I):
         if len(I) == 1:
             I = I[0]
             if isinstance(I, Sequence):
-                handler = IntegratorHandler.build_list(I, form=self)
-                self.bintegrators.extend(handler)
+                self.bintegrators.extend(I)
             else:
-                handler = IntegratorHandler(I, form=self)
-                self.bintegrators.append(handler)
+                self.bintegrators.append(I)
         elif len(I) >= 2:
-            handler = IntegratorHandler.build_list(I, form=self)
-            self.bintegrators.extend(handler)
+            self.bintegrators.extend(I)
         else:
             raise RuntimeError("add_boundary_integrator() is called with no arguments.")
 
-        return handler
+        return I
 
     def number_of_domain_integrators(self) -> int:
         return len(self.dintegrators)

--- a/fealpy/torch/fem/form.py
+++ b/fealpy/torch/fem/form.py
@@ -1,0 +1,29 @@
+
+from typing import Sequence
+
+from torch import Tensor
+
+from .integrator import Integrator
+
+
+class IntegratorHandler():
+    def __init__(self, integrator: Integrator, form=None) -> None:
+        self.integrator = integrator
+        self.form = form
+        self._value = None
+
+    @classmethod
+    def build_list(cls, integrators: Sequence[Integrator], form=None):
+        return [cls(integrator, form) for integrator in integrators]
+
+    @property
+    def value(self) -> Tensor:
+        if self._value is None:
+            self._value = self.integrator.assembly()
+        return self._value
+
+    def assembly(self) -> Tensor:
+        return self.integrator.assembly()
+
+    def clear(self) -> None:
+        self._value = None

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -1,41 +1,38 @@
 
-from typing import Union, Generic, TypeVar, Callable
+from typing import Union, Callable
 
 from torch import Tensor
 
-from ..functionspace.space import FunctionSpace
+from ..functionspace.space import FunctionSpace as _FunctionSpace
 
-_FS = TypeVar('_FS', bound=FunctionSpace)
 Index = Union[int, slice, Tensor]
 _S = slice(None)
 
 
-class Integrator(Generic[_FS]):
+class Integrator():
     r"""@brief The base class for integrators on function spaces."""
-    def assembly(self, space: _FS, index: Index=_S) -> Tensor:
-        r"""Assembly the matrix or vector."""
-        raise NotImplementedError
+    pass
 
 
-class DomainIntegrator(Integrator[_FS]):
-    def assembly_cell_matrix(self, space: _FS, index: Index=_S) -> Tensor:
+class DomainIntegrator(Integrator):
+    def assembly_cell_matrix(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         r"""Assembly matrix for each cell. Returns a tensor of shape (NC, ldof, ldof)."""
         raise NotImplementedError
 
 
-class BoundaryIntegrator(Integrator[_FS]):
-    def assembly_face_matrix(self, space: _FS, index: Index=_S) -> Tensor:
+class BoundaryIntegrator(Integrator):
+    def assembly_face_matrix(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         r"""Assembly matrix for each face into global. Returns a tensor of shape (gdof, gdof)."""
         raise NotImplementedError
 
 
-class DomainSourceIntegrator(Integrator[_FS]):
-    def assembly_cell_vector(self, space: _FS, index: Index=_S) -> Tensor:
+class DomainSourceIntegrator(Integrator):
+    def assembly_cell_vector(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         raise NotImplementedError
 
 
-class BoundarySourceIntegrator(Integrator[_FS]):
-    def assembly_face_vector(self, space: _FS, index: Index=_S) -> Tensor:
+class BoundarySourceIntegrator(Integrator):
+    def assembly_face_vector(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         raise NotImplementedError
 
 

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -12,7 +12,9 @@ _S = slice(None)
 
 class Integrator(Generic[_FS]):
     r"""@brief The base class for integrators on function spaces."""
-    pass
+    def assembly(self, space: _FS, index: Index=_S) -> Tensor:
+        r"""Assembly the matrix or vector."""
+        raise NotImplementedError
 
 
 class DomainIntegrator(Integrator[_FS]):

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -1,5 +1,5 @@
 
-from typing import Union, Callable
+from typing import Union, Callable, Optional
 
 from torch import Tensor
 
@@ -11,27 +11,46 @@ _S = slice(None)
 
 class Integrator():
     r"""@brief The base class for integrators on function spaces."""
-    pass
+    _value: Optional[Tensor]
+    _assembly: str
+
+    def assembly(self, space: _FunctionSpace) -> Tensor:
+        if hasattr(self, '_value') and self._value is not None:
+            return self._value
+        else:
+            if not hasattr(self, '_assembly'):
+                raise NotImplementedError("Assembly method not defined.")
+            if self._assembly == 'assembly':
+                raise ValueError("Can not use assembly method name 'assembly'.")
+            self._value = getattr(self, self._assembly)(space)
+            return self._value
+
+    def clear(self):
+        self._value = None
 
 
 class DomainIntegrator(Integrator):
+    _assembly = 'assembly_cell_matrix'
     def assembly_cell_matrix(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         r"""Assembly matrix for each cell. Returns a tensor of shape (NC, ldof, ldof)."""
         raise NotImplementedError
 
 
 class BoundaryIntegrator(Integrator):
+    _assembly = 'assembly_face_matrix'
     def assembly_face_matrix(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         r"""Assembly matrix for each face into global. Returns a tensor of shape (gdof, gdof)."""
         raise NotImplementedError
 
 
 class DomainSourceIntegrator(Integrator):
+    _assembly = 'assembly_cell_vector'
     def assembly_cell_vector(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         raise NotImplementedError
 
 
 class BoundarySourceIntegrator(Integrator):
+    _assembly = 'assembly_face_vector'
     def assembly_face_vector(self, space: _FunctionSpace, index: Index=_S) -> Tensor:
         raise NotImplementedError
 

--- a/fealpy/torch/fem/linear_form.py
+++ b/fealpy/torch/fem/linear_form.py
@@ -1,83 +1,130 @@
 
-from typing import Generic, TypeVar, Optional, List, overload, Sequence
+from typing import TypeVar, Optional, List
 
 import torch
 from torch import Tensor
 
 from .. import logger
 from ..functionspace.space import FunctionSpace
-from .integrator import DomainSourceIntegrator as _DSI
-from .integrator import BoundarySourceIntegrator as _BSI
+from .form import IntegratorHandler, Form
 
 
 _FS = TypeVar('_FS', bound=FunctionSpace)
 
 
-class LinearForm(Generic[_FS]):
+class LinearForm(Form[_FS]):
     r"""@brief"""
-    def __init__(self, space: _FS):
+    def __init__(self, space: _FS, retain_ints: bool=False, batch_size: int=0):
         self.space = space
-        self.dintegrators: List[_DSI[_FS]] = []
-        self.bintegrators: List[_BSI[_FS]] = []
+        self.dintegrators: List[IntegratorHandler] = []
+        self.bintegrators: List[IntegratorHandler] = []
         self._M: Optional[Tensor] = None
+        self.retain_ints = retain_ints
+        self.batch_size = batch_size
 
-    @overload
-    def add_domain_integrator(self, I: _DSI[_FS]) -> None: ...
-    @overload
-    def add_domain_integrator(self, I: Sequence[_DSI[_FS]]) -> None: ...
-    @overload
-    def add_domain_integrator(self, *I: _DSI[_FS]) -> None: ...
-    def add_domain_integrator(self, *I):
-        if len(I) == 1:
-            I = I[0]
-            if isinstance(I, Sequence):
-                self.dintegrators.extend(I)
-            else:
-                self.dintegrators.append(I)
-        elif len(I) >= 2:
-            self.dintegrators.extend(I)
-        else:
-            logger.warning("add_domain_integrator() is called with no arguments.")
-
-    @overload
-    def add_boundary_integrator(self, I: _BSI[_FS]) -> None: ...
-    @overload
-    def add_boundary_integrator(self, I: Sequence[_BSI[_FS]]) -> None: ...
-    @overload
-    def add_boundary_integrator(self, *I: _BSI[_FS]) -> None: ...
-    def add_boundary_integrator(self, *I):
-        if len(I) == 1:
-            I = I[0]
-            if isinstance(I, Sequence):
-                self.bintegrators.extend(I)
-            else:
-                self.bintegrators.append(I)
-        elif len(I) >= 2:
-            self.bintegrators.extend(I)
-        else:
-            logger.warning("add_boundary_integrator() is called with no arguments.")
-
-    def assembly(self) -> Tensor:
-        r"""Assembly the linear form vector. Returns COO Tensor of shape (gdof,)."""
+    def _single_assembly(self) -> Tensor:
         space = self.space
-        cell2dof = space.cell_to_dof()
-        NC = cell2dof.shape[0]
+        device = space.device
         gdof = space.number_of_global_dofs()
         ldof = space.number_of_local_dofs()
+        cell2dof = space.cell_to_dof()
+        NC = cell2dof.shape[0]
+        global_vec_shape = (gdof,)
 
-        bb = torch.zeros((NC, ldof), dtype=space.ftype)
-        bb = self.dintegrators[0].assembly_cell_vector(space)
+        if len(self.dintegrators) > 0:
+            local_vec_shape = (NC, ldof)
+            cell_vec = torch.zeros(local_vec_shape, dtype=space.ftype, device=device)
 
-        for di in self.dintegrators[1:]:
-            bb = bb + di.assembly_cell_vector(space)
+            for i in range(len(self.dintegrators)):
+                di = self.dintegrators[i]
+                cell_vec = cell_vec + di.assembly_cell_vector(space)
 
-        indices = cell2dof.ravel().unsqueeze(0)
-        V = torch.sparse_coo_tensor(indices, bb.ravel(), (gdof,))
+                if not self.retain_ints:
+                    di.clear()
 
-        for bi in self.bintegrators:
+            indices = cell2dof.ravel().unsqueeze(0)
+            V = torch.sparse_coo_tensor(indices, cell_vec.ravel(), global_vec_shape)
+
+        else:
+            V = torch.sparse_coo_tensor(
+                torch.empty((1, 0), dtype=space.itype, device=device),
+                torch.empty((0,), dtype=space.ftype, device=device),
+            )
+
+        for i in range(len(self.bintegrators)):
+            bi = self.bintegrators[i]
             V = V + bi.assembly_face_vector(space)
+
+            if not self.retain_ints:
+                bi.clear()
 
         self._V = V.coalesce()
         logger.info(f"Linear form vector constructed, with shape {list(V.shape)}.")
 
         return self._V
+
+    def _batch_assembly(self) -> Tensor:
+        space = self.space
+        device = space.device
+        gdof = space.number_of_global_dofs()
+        ldof = space.number_of_local_dofs()
+        cell2dof = space.cell_to_dof()
+        NC = cell2dof.shape[0]
+        batch = self.batch_size
+        global_vec_shape = (gdof, batch)
+
+        if len(self.dintegrators) > 0:
+            local_vec_shape = (NC, ldof, batch)
+            cell_vec = torch.zeros(local_vec_shape, dtype=space.ftype, device=device)
+
+            for i in range(len(self.dintegrators)):
+                di = self.dintegrators[i]
+                new_vec = di.assembly_cell_vector(space)
+
+                if new_vec.ndim == 2:
+                    new_vec = new_vec.unsqueeze(-1).expand(local_vec_shape)
+
+                cell_vec = cell_vec + new_vec
+
+                if not self.retain_ints:
+                    di.clear()
+
+            indices = cell2dof.ravel().unsqueeze(0)
+            cv_flatten = cell_vec.reshape(-1, batch)
+            V = torch.sparse_coo_tensor(indices, cv_flatten, global_vec_shape)
+
+        else:
+            V = torch.sparse_coo_tensor(
+                torch.empty((1, 0), dtype=space.itype, device=device),
+                torch.empty((0, batch), dtype=space.ftype, device=device),
+            )
+
+        for i in range(len(self.bintegrators)):
+            bi = self.bintegrators[i]
+            new_vec = bi.assembly_face_vector(space)
+            values = new_vec.values()
+
+            if values.ndim == 1:
+                values = values.unsqueeze(-1).expand(-1, batch)
+                new_vec = torch.sparse_coo_tensor(
+                    values.indices(), values, global_vec_shape
+                )
+
+            V = V + new_vec
+
+            if not self.retain_ints:
+                bi.clear()
+
+        self._V = V.coalesce()
+        logger.info(f"Linear form vector constructed, with shape {list(V.shape)}.")
+
+        return self._V
+
+    def assembly(self) -> Tensor:
+        r"""Assembly the linear form vector. Returns COO Tensor of shape (gdof,)."""
+        if self.batch_size == 0:
+            return self._single_assembly()
+        elif self.batch_size > 0:
+            return self._batch_assembly()
+        else:
+            raise ValueError("batch_size must be a non-negative integer.")

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -4,12 +4,13 @@ from typing import Optional
 from torch import Tensor
 
 from ..mesh import HomoMesh
+from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import bilinear_integral
-from .integrator import DomainIntegrator, _FS, _S, Index, CoefLike
+from .integrator import DomainIntegrator, _S, Index, CoefLike
 
 
-class ScalarDiffusionIntegrator(DomainIntegrator[_FS]):
+class ScalarDiffusionIntegrator(DomainIntegrator):
     r"""The diffusion integrator for function spaces based on homogeneous meshes."""
     def __init__(self, c: Optional[CoefLike]=None, q: int=3, *,
                  batched: bool=False) -> None:

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -1,19 +1,21 @@
 
 from typing import Optional
 
-import torch
 from torch import Tensor
 
 from ..mesh import HomoMesh
-from ..utils import process_coef_func, is_scalar
+from ..utils import process_coef_func
+from ..functional import bilinear_integral
 from .integrator import DomainIntegrator, _FS, _S, Index, CoefLike
 
 
 class ScalarDiffusionIntegrator(DomainIntegrator[_FS]):
     r"""The diffusion integrator for function spaces based on homogeneous meshes."""
-    def __init__(self, c: Optional[CoefLike]=None, q: int=3) -> None:
+    def __init__(self, c: Optional[CoefLike]=None, q: int=3, *,
+                 batched: bool=False) -> None:
         self.coef = c
         self.q = q
+        self.batched = batched
 
     def assembly_cell_matrix(self, space: _FS, index: Index=_S) -> Tensor:
         coef = self.coef
@@ -25,24 +27,10 @@ class ScalarDiffusionIntegrator(DomainIntegrator[_FS]):
                                f"homogeneous meshes, but {type(mesh).__name__} is"
                                "not a subclass of HomoMesh.")
 
-        cm = mesh.entity_measure('cell', index)
-        NC = cm.size(0)
+        cm = mesh.entity_measure('cell', index=index)
         qf = mesh.integrator(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
-        NQ = ws.size(0)
+        gphi = space.grad_basis(bcs, index=index, variable='x')
+        coef = process_coef_func(coef, mesh=mesh, index=index)
 
-        gphi = space.grad_basis(bcs, index, variable='x')
-
-        if coef is None:
-            return torch.einsum('q, qci..., qcj..., c -> cij', ws, gphi, gphi, cm)
-        else:
-            coef = process_coef_func(coef, mesh=mesh, index=index)
-            if is_scalar(coef):
-                return torch.einsum('q, qci..., qcj..., c -> cij', ws, gphi, gphi, cm) * coef
-            else:
-                if coef.shape == (NC, ):
-                    return torch.einsum('q, qci..., qcj..., c -> cij', ws, gphi, gphi, cm*coef)
-                elif coef.shape == (NQ, NC):
-                    return torch.einsum('q, qci..., qcj..., c, qc -> cij', ws, gphi, gphi, cm, coef)
-                else:
-                    RuntimeError(f'coef shape {coef.shape} is not supported.')
+        return bilinear_integral(gphi, gphi, ws, cm, coef, batched=self.batched)

--- a/fealpy/torch/fem/scalar_source_integrator.py
+++ b/fealpy/torch/fem/scalar_source_integrator.py
@@ -4,9 +4,10 @@ from typing import Optional
 from torch import Tensor
 
 from ..mesh import HomoMesh
+from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import linear_integral
-from .integrator import DomainSourceIntegrator, _FS, _S, Index, CoefLike
+from .integrator import DomainSourceIntegrator, _S, Index, CoefLike
 
 
 class ScalarSourceIntegrator(DomainSourceIntegrator):

--- a/fealpy/torch/fem/scalar_source_integrator.py
+++ b/fealpy/torch/fem/scalar_source_integrator.py
@@ -1,21 +1,23 @@
 
-from typing import Callable, Union
+from typing import Optional
 
-import torch
 from torch import Tensor
 
 from ..mesh import HomoMesh
-from ..utils import process_coef_func, is_scalar
-from .integrator import DomainSourceIntegrator, _FS, _S, Index
+from ..utils import process_coef_func
+from ..functional import linear_integral
+from .integrator import DomainSourceIntegrator, _FS, _S, Index, CoefLike
 
 
 class ScalarSourceIntegrator(DomainSourceIntegrator):
-    def __init__(self, source: Union[Callable, int, float, Tensor], q: int=3):
-        r""""""
+    r"""The domain source integrator for function spaces based on homogeneous meshes."""
+    def __init__(self, source: Optional[CoefLike]=None, q: int=3, *,
+                 batched: bool=False):
         self.f = source
         self.q = q
+        self.batched = batched
 
-    def assembly_cell_vector(self, space: _FS, index: Index=_S):
+    def assembly_cell_vector(self, space: _FS, index: Index=_S) -> Tensor:
         f = self.f
         q = self.q
         mesh = getattr(space, 'mesh', None)
@@ -26,20 +28,9 @@ class ScalarSourceIntegrator(DomainSourceIntegrator):
                                "not a subclass of HomoMesh.")
 
         cm = mesh.entity_measure('cell', index=index)
-        NC = cm.size(0)
         qf = mesh.integrator(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
-        NQ = ws.size(0)
-
         phi = space.basis(bcs, index=index, variable='x')
         val = process_coef_func(f, bcs, mesh, index)
 
-        if is_scalar(val):
-            return val * torch.einsum('q, qci, c -> ci', ws, phi, cm)
-        else:
-            if val.shape == (NC, ):
-                return torch.einsum('q, c, qci, c -> ci', ws, val, phi, cm)
-            elif val.shape == (NQ, NC):
-                return torch.einsum('q, qc, qci, c -> ci', ws, val, phi, cm)
-            else:
-                raise RuntimeError(f'source value shape {val.shape} is not supported.')
+        return linear_integral(phi, ws, cm, val, batched=self.batched)

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -27,7 +27,7 @@ def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
 
     Returns:
         Tensor[C, I]: The result of the integration.
-        If `batched == True`, the shape of the result is (B, C, I).
+        If `batched == True`, the shape of the result is (C, I, B).
     """
     if coef is None:
         return einsum('q, c, qci -> ci', weights, measure, input)
@@ -38,7 +38,7 @@ def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
     if is_scalar(coef):
         return einsum('q, c, qci -> ci', weights, measure, input) * coef
     elif is_tensor(coef):
-        out_subs = 'bci' if batched else 'ci'
+        out_subs = 'cib' if batched else 'ci'
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
         return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
     else:
@@ -62,7 +62,7 @@ def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: 
 
     Returns:
         Tensor[C, I, J]: The result of the integration.
-        If `batched == True`, the shape of the output is (B, C, I, J).
+        If `batched == True`, the shape of the output is (C, I, J, B).
     """
     if coef is None:
         return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2)
@@ -73,7 +73,7 @@ def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: 
     if is_scalar(coef):
         return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2) * coef
     elif is_tensor(coef):
-        out_subs = 'bcij' if batched else 'cij'
+        out_subs = 'cijb' if batched else 'cij'
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
         return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
     else:

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -1,0 +1,80 @@
+
+import builtins
+from typing import Union, Callable
+
+from torch import Tensor, einsum
+
+from .utils import is_scalar, is_tensor, get_coef_subscripts
+
+
+Number = Union[builtins.int, builtins.float]
+CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
+
+
+def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
+                    coef: Union[Number, Tensor, None]=None,
+                    batched: bool=False) -> Tensor:
+    r"""Numerical integration.
+
+    Args:
+        input (Tensor[Q, C, I]): The values on the quadrature points to be integrated.
+        weights (Tensor[Q,]): The weights of the quadrature points.
+        measure (Tensor[C,]): The measure of the quadrature points.
+        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
+        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
+        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+        batched (bool, optional): Whether the coef are batched. Defaults to False.
+
+    Returns:
+        Tensor[C, I]: The result of the integration.
+        If `batched == True`, the shape of the result is (B, C, I).
+    """
+    if coef is None:
+        return einsum('q, c, qci -> ci', weights, measure, input)
+
+    NQ = weights.shape[0]
+    NC = measure.shape[0]
+
+    if is_scalar(coef):
+        return einsum('q, c, qci -> ci', weights, measure, input) * coef
+    elif is_tensor(coef):
+        out_subs = 'bci' if batched else 'ci'
+        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
+        return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
+    else:
+        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")
+
+
+def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: Tensor,
+                      coef: Union[Number, Tensor, None]=None,
+                      batched: bool=False) -> Tensor:
+    r"""Numerical integration.
+
+    Args:
+        input1 (Tensor[Q, C, I, ...]): The values on the quadrature points to be integrated.
+        input2 (Tensor[Q, C, J, ...]): The values on the quadrature points to be integrated.
+        weights (Tensor[Q,]): The weights of the quadrature points.
+        measure (Tensor[C,]): The measure of the quadrature points.
+        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
+        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
+        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+        batched (bool, optional): Whether the coef are batched. Defaults to False.
+
+    Returns:
+        Tensor[C, I, J]: The result of the integration.
+        If `batched == True`, the shape of the output is (B, C, I, J).
+    """
+    if coef is None:
+        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2)
+
+    NQ = weights.shape[0]
+    NC = measure.shape[0]
+
+    if is_scalar(coef):
+        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2) * coef
+    elif is_tensor(coef):
+        out_subs = 'bcij' if batched else 'cij'
+        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
+        return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
+    else:
+        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")

--- a/fealpy/torch/functionspace/lagrange_fe_space.py
+++ b/fealpy/torch/functionspace/lagrange_fe_space.py
@@ -1,5 +1,5 @@
 
-from typing import Union, TypeVar, Generic, Callable
+from typing import Union, TypeVar, Generic, Callable, Optional
 
 import torch
 from torch import Tensor
@@ -11,6 +11,7 @@ from .dofs import LinearMeshCFEDof
 
 _MT = TypeVar('_MT', bound=Mesh)
 Index = Union[int, slice, Tensor]
+Number = Union[int, float]
 _S = slice(None)
 
 
@@ -52,30 +53,35 @@ class LagrangeFESpace(FunctionSpace, Generic[_MT]):
         else:
             raise RuntimeError("boundary dof is not supported by discontinuous spaces.")
 
-    def interpolate(self, gD: Union[Callable[..., Tensor], Tensor],
-                    uh: Tensor,
-                    index: Index=_S):
-        ipoints = self.interpolation_points() # TODO: 直接获取过滤后的插值点
-        GD = self.mesh.geo_dimension()
+    def interpolate(self, source: Union[Callable[..., Tensor], Tensor, Number],
+                    uh: Tensor, dim: Optional[int]=None, index: Index=_S) -> Tensor:
+        """@brief Interpolate the given Tensor or function `source` to the dofs.
 
-        if callable(gD):
-            gD = gD(ipoints[index])
+        @params source: The source to be interpolated.
+        @params uh: The output Tensor.
+        @params dim: The dimension of the dofs in the uh and source.
+        This arg will be set to -1 if the `doforder` of space is 'sdofs' when not given,\
+        otherwise 0.
+        @params index: The index of the dofs to be interpolated.
 
-        if (len(uh.shape) == 1) or (self.doforder == 'vdims'):
-            if len(uh.shape) == 1 and gD.shape[-1] == 1:
-                gD = gD.squeeze(-1)
-            uh[index] = gD
+        @return: The interpolated Tensor `uh`.
+        """
+        if callable(source):
+            ipoints = self.interpolation_points() # TODO: 直接获取过滤后的插值点
+            source = source(ipoints[index])
 
-        elif self.doforder == 'sdofs':
-            if isinstance(gD, (int, float)):
-                uh[..., index] = gD
-            elif isinstance(gD, Tensor):
-                if gD.shape == (GD, ):
-                    uh[..., index] = gD[:, None]
-                else:
-                    uh[..., index] = gD.T
-            else:
-                raise ValueError("Unsupported type for gD. Must be a callable, int, float, or Tensor.")
+        if uh.ndim == 1:
+            if isinstance(source, Tensor) and source.shape[-1] == 1:
+                source = source.squeeze(-1)
+            uh[index] = source
+            return uh
+
+        if dim is None:
+            dim = -1 if (getattr(self, 'doforder', None) == 'sdofs') else 0
+
+        slicing = [slice(None)] * uh.ndim
+        slicing[dim] = index
+        uh[slicing] = source
 
         return uh
 

--- a/fealpy/torch/functionspace/lagrange_fe_space.py
+++ b/fealpy/torch/functionspace/lagrange_fe_space.py
@@ -27,6 +27,7 @@ class LagrangeFESpace(FunctionSpace, Generic[_MT]):
 
         self.ftype = mesh.ftype
         self.itype = mesh.ds.itype
+        self.device = mesh.device
         self.TD = mesh.top_dimension()
         self.GD = mesh.geo_dimension()
 

--- a/fealpy/torch/functionspace/space.py
+++ b/fealpy/torch/functionspace/space.py
@@ -2,9 +2,8 @@
 from typing import Union
 from abc import ABCMeta, abstractmethod
 
+import torch
 from torch import Tensor
-
-from ..mesh import Mesh
 
 Index = Union[int, slice, Tensor]
 _S = slice(None)
@@ -12,7 +11,9 @@ _S = slice(None)
 
 class FunctionSpace(metaclass=ABCMeta):
     r"""THe base class of function spaces"""
-    mesh: Mesh
+    device: torch.device
+    ftype: torch.dtype
+    itype: torch.dtype
 
     ### basis
     @abstractmethod

--- a/fealpy/torch/functionspace/space.py
+++ b/fealpy/torch/functionspace/space.py
@@ -1,11 +1,12 @@
 
-from typing import Union
+from typing import Union, Callable, Optional
 from abc import ABCMeta, abstractmethod
 
 import torch
 from torch import Tensor
 
 Index = Union[int, slice, Tensor]
+Number = Union[int, float]
 _S = slice(None)
 
 
@@ -35,3 +36,8 @@ class FunctionSpace(metaclass=ABCMeta):
 
     # relationships
     def cell_to_dof(self) -> Tensor: raise NotImplementedError
+
+    # interpolation
+    def interpolate(self, source: Union[Callable[..., Tensor], Tensor, Number],
+                    uh: Tensor, dim: Optional[int]=None, index: Index=_S) -> Tensor:
+        raise NotImplementedError

--- a/fealpy/torch/solver/cg.py
+++ b/fealpy/torch/solver/cg.py
@@ -9,7 +9,8 @@ from torch.autograd import Function
 from .. import logger
 
 
-def sparse_cg(A: Tensor, b: Tensor, x0: Optional[Tensor]=None,
+def sparse_cg(A: Tensor, b: Tensor, x0: Optional[Tensor]=None, *,
+              batch_first: bool=False,
               atol: float=1e-12, rtol: float=1e-8, maxiter: Optional[int]=10000) -> Tensor:
     r"""Solve a linear system Ax = b using the Conjugate Gradient (CG) method.
 

--- a/fealpy/torch/utils.py
+++ b/fealpy/torch/utils.py
@@ -50,16 +50,16 @@ def is_tensor(input: Union[int, float, Tensor]) -> bool:
 
 def get_coef_subscripts(shape: Tensor, nq: int, nc: int, batched: bool):
     if batched:
-        coef_shape = shape[1:]
+        coef_shape = shape[:-1]
         if coef_shape == (nq, nc):
-            subs = "bqc"
+            subs = "qcb"
         elif coef_shape == (nq, ):
-            subs = "bq"
+            subs = "qb"
         elif coef_shape == (nc, ):
-            subs = "bc"
+            subs = "cb"
         else:
-            raise RuntimeError(f"The shape of the coef should be (Batch, {nq}, {nc}), "
-                               f"(Batch, {nq}) or (Batch, {nc}), but got {tuple(shape)}.")
+            raise RuntimeError(f"The shape of the coef should be ({nq}, {nc}, Batch), "
+                               f"({nq}, Batch) or ({nc}, Batch), but got {tuple(shape)}.")
 
     else:
         coef_shape = shape

--- a/fealpy/torch/utils.py
+++ b/fealpy/torch/utils.py
@@ -1,8 +1,8 @@
 
 import builtins
-from typing import Optional, Union, Callable, TypeGuard
+from typing import Optional, Union, Callable
 
-from torch import Tensor, einsum
+from torch import Tensor
 
 from .mesh import HomoMesh
 
@@ -11,8 +11,13 @@ CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
 Index = Union[slice, Tensor, int]
 
 
-def process_coef_func(coef: CoefLike, bcs: Optional[Tensor]=None, mesh: Optional[HomoMesh]=None,
-                      index: Optional[Tensor]=None):
+def process_coef_func(
+    coef: Optional[CoefLike],
+    bcs: Optional[Tensor]=None,
+    mesh: Optional[HomoMesh]=None,
+    index: Optional[Tensor]=None
+):
+    r"""Fetch the result Tensor if `coef` is a function."""
     if callable(coef):
         if index is None:
             raise RuntimeError('The index should be provided for coef functions.')
@@ -30,14 +35,14 @@ def process_coef_func(coef: CoefLike, bcs: Optional[Tensor]=None, mesh: Optional
     return coef_val
 
 
-def is_scalar(input: Union[int, float, Tensor]):
+def is_scalar(input: Union[int, float, Tensor]) -> bool:
     if isinstance(input, Tensor):
         return input.numel() == 1
     else:
         return isinstance(input, (int, float))
 
 
-def is_tensor(input: Union[int, float, Tensor]) -> TypeGuard[Tensor]:
+def is_tensor(input: Union[int, float, Tensor]) -> bool:
     if isinstance(input, Tensor):
         return input.numel() >= 2
     return False
@@ -69,68 +74,3 @@ def get_coef_subscripts(shape: Tensor, nq: int, nc: int, batched: bool):
                                f"({nq}) or ({nc}), but got {tuple(shape)}.")
 
     return subs
-
-
-def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
-                    coef: Union[Number, Tensor, None]=None,
-                    batched: bool=False) -> Tensor:
-    r"""Numerical integration.
-
-    Args:
-        input (Tensor[Q, C, I]): The values on the quadrature points to be integrated.
-        weights (Tensor[Q,]): The weights of the quadrature points.
-        measure (Tensor[C,]): The measure of the quadrature points.
-        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
-        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
-        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
-        batched (bool, optional): Whether the coef are batched. Defaults to False.
-
-    Returns:
-        Tensor[C, I]: The result of the integration.
-    """
-    if coef is None:
-        return einsum('q, c, qci -> ci', weights, measure, input)
-
-    NQ, NC = input.shape[:2]
-
-    if is_scalar(coef):
-        return einsum('q, c, qci -> ci', weights, measure, input) * coef
-    elif is_tensor(coef):
-        out_subs = 'bci' if batched else 'ci'
-        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
-        return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
-    else:
-        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")
-
-
-def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: Tensor,
-                      coef: Union[Number, Tensor, None]=None,
-                      batched: bool=False) -> Tensor:
-    r"""Numerical integration.
-
-    Args:
-        input1 (Tensor[Q, C, I, ...]): The values on the quadrature points to be integrated.
-        input2 (Tensor[Q, C, J, ...]): The values on the quadrature points to be integrated.
-        weights (Tensor[Q,]): The weights of the quadrature points.
-        measure (Tensor[C,]): The measure of the quadrature points.
-        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
-        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
-        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
-        batched (bool, optional): Whether the coef are batched. Defaults to False.
-
-    Returns:
-        Tensor[C, I, J]: The result of the integration.
-    """
-    if coef is None:
-        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2)
-
-    NQ, NC = input1.shape[:2]
-
-    if is_scalar(coef):
-        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2) * coef
-    elif is_tensor(coef):
-        out_subs = 'bcij' if batched else 'cij'
-        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
-        return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
-    else:
-        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")

--- a/fealpy/torch/utils.py
+++ b/fealpy/torch/utils.py
@@ -1,8 +1,8 @@
 
 import builtins
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, TypeGuard
 
-from torch import Tensor
+from torch import Tensor, einsum
 
 from .mesh import HomoMesh
 
@@ -35,3 +35,102 @@ def is_scalar(input: Union[int, float, Tensor]):
         return input.numel() == 1
     else:
         return isinstance(input, (int, float))
+
+
+def is_tensor(input: Union[int, float, Tensor]) -> TypeGuard[Tensor]:
+    if isinstance(input, Tensor):
+        return input.numel() >= 2
+    return False
+
+
+def get_coef_subscripts(shape: Tensor, nq: int, nc: int, batched: bool):
+    if batched:
+        coef_shape = shape[1:]
+        if coef_shape == (nq, nc):
+            subs = "bqc"
+        elif coef_shape == (nq, ):
+            subs = "bq"
+        elif coef_shape == (nc, ):
+            subs = "bc"
+        else:
+            raise RuntimeError(f"The shape of the coef should be (Batch, {nq}, {nc}), "
+                               f"(Batch, {nq}) or (Batch, {nc}), but got {tuple(shape)}.")
+
+    else:
+        coef_shape = shape
+        if coef_shape == (nq, nc):
+            subs = "qc"
+        elif coef_shape == (nq, ):
+            subs = "q"
+        elif coef_shape == (nc, ):
+            subs = "c"
+        else:
+            raise RuntimeError(f"The shape of the coef should be ({nq}, {nc}), "
+                               f"({nq}) or ({nc}), but got {tuple(shape)}.")
+
+    return subs
+
+
+def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
+                    coef: Union[Number, Tensor, None]=None,
+                    batched: bool=False) -> Tensor:
+    r"""Numerical integration.
+
+    Args:
+        input (Tensor[Q, C, I]): The values on the quadrature points to be integrated.
+        weights (Tensor[Q,]): The weights of the quadrature points.
+        measure (Tensor[C,]): The measure of the quadrature points.
+        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
+        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
+        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+        batched (bool, optional): Whether the coef are batched. Defaults to False.
+
+    Returns:
+        Tensor[C, I]: The result of the integration.
+    """
+    if coef is None:
+        return einsum('q, c, qci -> ci', weights, measure, input)
+
+    NQ, NC = input.shape[:2]
+
+    if is_scalar(coef):
+        return einsum('q, c, qci -> ci', weights, measure, input) * coef
+    elif is_tensor(coef):
+        out_subs = 'bci' if batched else 'ci'
+        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
+        return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
+    else:
+        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")
+
+
+def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: Tensor,
+                      coef: Union[Number, Tensor, None]=None,
+                      batched: bool=False) -> Tensor:
+    r"""Numerical integration.
+
+    Args:
+        input1 (Tensor[Q, C, I, ...]): The values on the quadrature points to be integrated.
+        input2 (Tensor[Q, C, J, ...]): The values on the quadrature points to be integrated.
+        weights (Tensor[Q,]): The weights of the quadrature points.
+        measure (Tensor[C,]): The measure of the quadrature points.
+        coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
+        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
+        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+        batched (bool, optional): Whether the coef are batched. Defaults to False.
+
+    Returns:
+        Tensor[C, I, J]: The result of the integration.
+    """
+    if coef is None:
+        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2)
+
+    NQ, NC = input1.shape[:2]
+
+    if is_scalar(coef):
+        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2) * coef
+    elif is_tensor(coef):
+        out_subs = 'bcij' if batched else 'cij'
+        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
+        return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
+    else:
+        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")


### PR DESCRIPTION
## fem.Integrators

### Update
- 简化了 typehint
- 将 linear 和 bilinear 类型的数值积分计算，以及对 coef 形状的处理，封装为单独的函数，大幅减少积分子之间的代码重复。

### New
- 加入可选的缓存机制，避免某些不变的积分在迭代中的重复计算。机制在启用后由模块自动完成，不改变用户的使用方式。
- 加入对批次数据的支持。现在 coef 和 source 可以接受第 0 个轴作为 batch 轴，输出**最后一个轴**是 batch 的张量。

## fem.LinearForm & fem.BilinearForm

### Update
- 修复了在没有添加任何 domain integrator 时（但是有 boundary integrator），assembly() 会出错的问题。现在即使未添加任何积分子，组装器仍可以输出一个空的（全零）稀疏张量。
- 在 LinearForm 的 assembly 方法中加入了 `return_dense` 参数并默认为 `True`。

### New
- 加入对批次数据的支持（参数 `batch_size`），输出最后一个轴是 batch 的稀疏张量。

## fem.DirichletBC

### New
- 加入对批次右端向量的支持，此处自动适应。要求 batch dimension 在最后一个轴。