### PR TITLE
Setup EIT app and update the torch module

### DIFF
--- a/app/eit/README.md
+++ b/app/eit/README.md
@@ -1,0 +1,1 @@
+# Electrical Impedence Tomography (EIT)

--- a/app/eit/box_tri_generate.py
+++ b/app/eit/box_tri_generate.py
@@ -13,7 +13,6 @@ from torch import Tensor, tensordot, rand
 import numpy as np
 import yaml
 from tqdm import tqdm
-# from viztracer import VizTracer
 
 from fealpy.torch.mesh import TriangleMesh
 from fealpy.torch import logger
@@ -61,7 +60,7 @@ def neumann(points: Tensor):
     kwargs = {'dtype': points.dtype, "device": points.device}
     theta = torch.arctan2(y, x)
     freq = torch.tensor(FREQ, **kwargs)
-    return torch.sin(tensordot(freq, theta, dims=0))
+    return torch.cos(tensordot(freq, theta, dims=0))
 
 
 def main(sigma_iterable: Sequence[int], seed=0, index=0):
@@ -92,6 +91,8 @@ def main(sigma_iterable: Sequence[int], seed=0, index=0):
             rads=rads.cpu().numpy()
         )
 
+    return
+
 
 def estimate_space_occupied(n_float: int, n_bool: int, n_samples: int, dtype: str):
     if dtype == torch.float32:
@@ -116,7 +117,7 @@ if __name__ == "__main__":
     import os
 
     process_num = config['process_num']
-    space_occ = estimate_space_occupied(EXT * 8 * len(FREQ),
+    space_occ = estimate_space_occupied(EXT * 4 * len(FREQ),
                                         (EXT+1)**2,
                                         config['tail'] - config['head'],
                                         DTYPE)
@@ -157,11 +158,6 @@ if __name__ == "__main__":
 
     PART = 4
     TM = int(time())
-    # tracer = VizTracer()
-    # tracer.start()
-    # main(NUM, 999, 0)
-    # tracer.stop()
-    # tracer.save(f'{output_folder}/{TM}.json')
 
     pool.apply_async(main, (NUM[0::PART], 621 + TM, 0))
     pool.apply_async(main, (NUM[1::PART], 928 + TM, 1))

--- a/app/eit/box_tri_generate.py
+++ b/app/eit/box_tri_generate.py
@@ -1,0 +1,169 @@
+"""
+此脚本用于生成数据集，每个样本包含多个 gD & gN 数据通道和标签。
+求解区域为 [-1, 1], [-1, 1]。
+"""
+
+import os
+from typing import Sequence
+from time import time
+import argparse
+
+import torch
+from torch import Tensor, tensordot, rand
+import numpy as np
+import yaml
+from tqdm import tqdm
+
+from fealpy.torch.mesh import TriangleMesh
+from fealpy.torch import logger
+
+from data_generator import EITDataGenerator
+
+logger.setLevel('WARNING')
+parser = argparse.ArgumentParser()
+parser.add_argument("config", help="path of the .yaml file")
+
+
+def levelset(p: Tensor, centers: Tensor, radius: Tensor):
+    """
+    Calculate level set function value.
+    """
+    struct = p.shape[:-1]
+    p = p.reshape(-1, p.shape[-1])
+    dis = torch.norm(p[:, None, :] - centers[None, :, :], dim=-1) # (N, NCir)
+    ret, _ = torch.min(dis - radius[None, :], dim=-1) # (N, )
+    return ret.reshape(struct)
+
+
+args = parser.parse_args()
+with open(args.config, "r") as f:
+    config = yaml.load(f, Loader=yaml.FullLoader)
+
+
+EXT = config['data']['ext']
+SIGMA = config['data']['sigma']
+NUM_CIR = config['data'].get('num_cir', 3)
+FREQ = config['data']['freq']
+DTYPE = getattr(torch, config['data']['dtype'])
+DEVICE = config['data'].get('device', None)
+output_folder = config['output_folder']
+kwargs = {"dtype": DTYPE, "device": DEVICE}
+os.path.join(output_folder, "")
+
+if not os.path.exists(output_folder):
+    os.makedirs(output_folder)
+
+
+def neumann(points: Tensor):
+    x = points[..., 0]
+    y = points[..., 1]
+    kwargs = {'dtype': points.dtype, "device": points.device}
+    theta = torch.arctan2(y, x)
+    freq = torch.tensor(FREQ, **kwargs)
+    return torch.sin(tensordot(freq, theta, dims=0))
+
+
+def main(sigma_iterable: Sequence[int], seed=0, index=0):
+    torch.manual_seed(seed)
+    mesh = TriangleMesh.from_box((-1, 1, -1, 1), EXT, EXT, ftype=DTYPE, device=DEVICE)
+
+    for sigma_idx in tqdm(sigma_iterable,
+                          desc=f"task{index}",
+                          dynamic_ncols=True,
+                          unit='sample',
+                          position=index):
+        ctrs = rand(NUM_CIR, 2, **kwargs) * 1.6 - 0.8 # (NCir, GD)
+        b, _ = torch.min(0.9-torch.abs(ctrs), axis=-1) # (NCir, )
+        rads = rand(NUM_CIR, **kwargs) * (b-0.1) + 0.1 # (NCir, )
+        ls_fn = lambda p: levelset(p, ctrs, rads)
+
+        generator = EITDataGenerator(
+            mesh=mesh,
+            sigma_vals=SIGMA,
+            levelset=ls_fn
+        )
+        gd, gn = generator.run(neumann, batched=True)
+        data = torch.stack([gd, gn], dim=1) # (Batch, 2, bd_bof)
+        torch.save(
+            dict(data=data, label=generator.label()),
+            os.path.join(output_folder, f'{sigma_idx}.pt')
+        )
+
+
+def estimate_space_occupied(n_float: int, n_bool: int, n_samples: int, dtype: str):
+    if dtype == torch.float32:
+        single = n_float * 4 + n_bool
+    elif dtype == torch.float64:
+        single = n_float * 8 + n_bool
+    else:
+        raise ValueError(f"Unsupported dtype '{DTYPE}'.")
+    return n_samples * single
+
+
+def _unit(bytes: int):
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(np.floor(np.log(bytes) / np.log(1024)))
+    if i == 0:
+        return f"{bytes:.2f} {size_name[i]}"
+    else:
+        return f"{bytes / 1024 ** i:.2f} {size_name[i]}"
+
+
+if __name__ == "__main__":
+    import os
+
+    process_num = config['process_num']
+    space_occ = estimate_space_occupied(EXT * 8 * len(FREQ),
+                                        (EXT+1)**2,
+                                        config['tail'] - config['head'],
+                                        DTYPE)
+
+    print("Start generating data...")
+    print(f"using {process_num} processes")
+    print("Config:")
+    print(f"    mesh: {EXT}x{EXT}")
+    print(f"    sigma(inclusion): {SIGMA[0]}")
+    print(f"    sigma(background): {SIGMA[1]}")
+    print(f"    number of circles: {NUM_CIR}")
+    print(f"    freq: {FREQ}")
+    print(f"    dtype: {DTYPE}")
+    print("Output:")
+    print(f"    data shape: {2}x{EXT*4}")
+    print(f"    n_channel: {len(FREQ)}")
+    print(f"    label shape: {EXT+1}x{EXT+1}")
+    print(f"    data index range: {config['head']}~{config['tail']}")
+    print(f"Space occupation estimate: {_unit(space_occ)},")
+    print(f"will be saved to folder: {output_folder}", end='\n\n')
+    signal_ = input("Continue? (y/n)")
+
+    if signal_ not in {'y', 'Y'}:
+        print("Aborted.")
+        exit(0)
+
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+
+    # from multiprocessing import Pool
+    from fealpy.ml import timer
+
+    # pool = Pool(process_num)
+    tmr = timer()
+    tmr.send(None)
+
+    NUM = tuple(range(config['head'], config['tail']))
+
+    PART = 4
+    TM = int(time())
+    main(NUM, 999, 0)
+
+    # pool.apply_async(main, (NUM[0::PART], 621 + TM, 0))
+    # pool.apply_async(main, (NUM[1::PART], 928 + TM, 1))
+    # pool.apply_async(main, (NUM[2::PART], 122 + TM, 2))
+    # pool.apply_async(main, (NUM[3::PART], 222 + TM, 3))
+
+    # pool.close()
+    # pool.join()
+
+    tmr.send('stop')
+
+    print("Done.")

--- a/app/eit/data_generator.py
+++ b/app/eit/data_generator.py
@@ -1,9 +1,10 @@
 
-from typing import Tuple, Callable, Union, Optional
+from typing import Tuple, Callable, Union
 
+from scipy.sparse import csr_matrix
+from scipy.sparse.linalg import spsolve
 import torch
 from torch import Tensor, cat
-from torch.linalg import lu_factor, lu_solve
 
 from fealpy.torch.mesh import Mesh
 from fealpy.torch.functionspace import LagrangeFESpace
@@ -17,66 +18,118 @@ from fealpy.torch.fem import (
 class EITDataGenerator():
     """Generate boundary voltage and current density data for EIT.
     """
-    def __init__(self, mesh: Mesh,
-                 sigma_vals: Tuple[float, float],
-                 levelset: Callable[[Tensor], Tensor]) -> None:
+    def __init__(self, mesh: Mesh) -> None:
         """Create a new EIT data generator.
 
         Args:
             mesh (Mesh): _description_
-            sigma_vals (Tuple[float, float]): Sigma value of inclusion and background.
-            levelset (Callable): _description_.
         """
+        kwargs = dict(dtype=mesh.ftype, device=mesh.device)
         space = LagrangeFESpace(mesh, p=1)
         ips = space.interpolation_points() # (Q, C, 2)
 
-        def _neumann_func(p: Tensor):
+        self.space = space
+        self.ips = ips
+        self._bsi = ScalarBoundarySourceIntegrator(None, zero_integral=True, batched=True)
+        self._di = ScalarDiffusionIntegrator(None)
+        self._bd_dof = torch.nonzero(space.is_boundary_dof(), as_tuple=True)[0]
+        gdof = space.number_of_global_dofs()
+        zeros = torch.zeros_like(self._bd_dof, **kwargs)
+        lform_c = LinearForm(space)
+        lform_c.add_integrator(ScalarBoundarySourceIntegrator(1.))
+        cdata = lform_c.assembly(return_dense=False)
+        self.c = torch.sparse_coo_tensor(
+            torch.stack([cdata.indices()[0], zeros], dim=0),
+            cdata.values(),
+            size=(gdof, 1)
+        )
+        self.ct = torch.sparse_coo_tensor(
+            torch.stack([zeros, cdata.indices()[0]], dim=0),
+            cdata.values(),
+            size=(1, gdof)
+        )
+        self.ZERO = torch.sparse_coo_tensor(
+            torch.zeros((2, 1), dtype=mesh.ds.itype, device=mesh.device),
+            torch.zeros((1,), **kwargs),
+            size=(1, 1)
+        )
+
+    def set_levelset(self, sigma_vals: Tuple[float, float],
+                     levelset: Callable[[Tensor], Tensor]) -> Tensor:
+        """Set the levelset function.
+
+        Args:
+            sigma_vals (Tuple[float, float]): Sigma value of inclusion and background.
+            levelset (Callable): _description_.
+
+        Retunrs:
+            Tensor: Label Tensor.
+        """
+        def _coef_func(p: Tensor):
             inclusion = levelset(p) < 0.
             sigma = torch.empty(p.shape[:2], dtype=p.dtype, device=p.device) # (Q, C)
             sigma[inclusion] = sigma_vals[0]
             sigma[~inclusion] = sigma_vals[1]
             return sigma
 
-        self.space = space
-        self.ips = ips
-        self.levelset = levelset
-        self.bform = BilinearForm(space)
-        self.bform.add_integrator(ScalarDiffusionIntegrator(_neumann_func))
-        self._A = self.bform.assembly()
-        self._bd_dof = space.is_boundary_dof()
+        space = self.space
 
-        c = self._bd_dof.to(mesh.ftype)[None, :]
-        ZERO = torch.zeros((1,1), dtype=mesh.ftype, device=mesh.device)
-        _A_n = cat([cat([self._A.to_dense(), c], dim=0),
-                    cat([c.T, ZERO], dim=0)], dim=1)
-        self._A_n_lu, self.pivots_n = lu_factor(_A_n)
+        bform = BilinearForm(space)
+        self._di.coef = _coef_func
+        self._di.clear(space_level=False)
+        bform.add_integrator(self._di)
+        self._A = bform.assembly()
+        A_n = cat([cat([self._A, self.c], dim=1),
+                   cat([self.ct, self.ZERO], dim=1)], dim=0).coalesce()
+        self._A_n_np = csr_matrix(
+            (A_n.values().cpu().numpy(), A_n.indices().cpu().numpy()),
+            shape=A_n.shape
+        )
 
-    def run(self, gn_source: Union[Callable[[Tensor], Tensor], Tensor],
-            batched=True) -> Tuple[Tensor, Tensor]:
+        node = space.mesh.entity('node')
+        return levelset(node) < 0.
+
+    def set_boundary(self, gn_source: Union[Callable[[Tensor], Tensor], Tensor],
+                     batched=True) -> Tensor:
+        """_summary_
+
+        Args:
+            gn_source (Union[Callable[[Tensor], Tensor], Tensor]): _description_
+            batched (bool, optional): _description_. Defaults to True.
+
+        Returns:
+            Tensor: gn Tensor.
+        """
         gn = gn_source(self.ips[self._bd_dof])
         batch_size = gn.size(0) if batched else 0
         lform = LinearForm(self.space, batch_size=batch_size)
-        lform.add_integrator(
-            ScalarBoundarySourceIntegrator(gn_source, zero_integral=True, batched=batched)
-        )
+        self._bsi.f = gn_source
+        self._bsi.batched = batched
+        self._bsi.clear(space_level=False)
+        lform.add_integrator(self._bsi)
         b_ = lform.assembly()
-        unsqueezed = False
+        self.unsqueezed = False
 
         if b_.ndim == 1:
             b_ = b_.unsqueeze(0)
-            unsqueezed = True
+            self.unsqueezed = True
 
         NUM = b_.size(0)
         ZERO = torch.zeros((NUM, 1), dtype=b_.dtype, device=b_.device)
-        b_ = torch.cat([b_, ZERO], dim=1)
-        uh = lu_solve(self._A_n_lu, self.pivots_n, b_, left=False)[:, :-1]
+        self.b_ = torch.cat([b_, ZERO], dim=1).cpu().numpy()
 
-        if unsqueezed:
+        return gn
+
+    def run(self) -> Tensor:
+        """_summary_
+
+        Returns:
+            Tensor: gd Tensor on CPU.
+        """
+        uh = spsolve(self._A_n_np, self.b_.T).T
+        uh = torch.from_numpy(uh) # cpu
+
+        if self.unsqueezed:
             uh = uh.squeeze(0)
 
-        return uh[..., self._bd_dof], gn
-
-    def label(self):
-        mesh = self.space.mesh
-        node = mesh.entity('node')
-        return self.levelset(node) < 0.
+        return uh[..., self._bd_dof.cpu()]

--- a/app/eit/data_generator.py
+++ b/app/eit/data_generator.py
@@ -1,0 +1,82 @@
+
+from typing import Tuple, Callable, Union, Optional
+
+import torch
+from torch import Tensor, cat
+from torch.linalg import lu_factor, lu_solve
+
+from fealpy.torch.mesh import Mesh
+from fealpy.torch.functionspace import LagrangeFESpace
+from fealpy.torch.fem import (
+    BilinearForm, LinearForm,
+    ScalarDiffusionIntegrator,
+    ScalarBoundarySourceIntegrator
+)
+
+
+class EITDataGenerator():
+    """Generate boundary voltage and current density data for EIT.
+    """
+    def __init__(self, mesh: Mesh,
+                 sigma_vals: Tuple[float, float],
+                 levelset: Callable[[Tensor], Tensor]) -> None:
+        """Create a new EIT data generator.
+
+        Args:
+            mesh (Mesh): _description_
+            sigma_vals (Tuple[float, float]): Sigma value of inclusion and background.
+            levelset (Callable): _description_.
+        """
+        space = LagrangeFESpace(mesh, p=1)
+        ips = space.interpolation_points() # (Q, C, 2)
+
+        def _neumann_func(p: Tensor):
+            inclusion = levelset(p) < 0.
+            sigma = torch.empty(p.shape[:2], dtype=p.dtype, device=p.device) # (Q, C)
+            sigma[inclusion] = sigma_vals[0]
+            sigma[~inclusion] = sigma_vals[1]
+            return sigma
+
+        self.space = space
+        self.ips = ips
+        self.levelset = levelset
+        self.bform = BilinearForm(space)
+        self.bform.add_integrator(ScalarDiffusionIntegrator(_neumann_func))
+        self._A = self.bform.assembly()
+        self._bd_dof = space.is_boundary_dof()
+
+        c = self._bd_dof.to(mesh.ftype)[None, :]
+        ZERO = torch.zeros((1,1), dtype=mesh.ftype, device=mesh.device)
+        _A_n = cat([cat([self._A.to_dense(), c], dim=0),
+                    cat([c.T, ZERO], dim=0)], dim=1)
+        self._A_n_lu, self.pivots_n = lu_factor(_A_n)
+
+    def run(self, gn_source: Union[Callable[[Tensor], Tensor], Tensor],
+            batched=True) -> Tuple[Tensor, Tensor]:
+        gn = gn_source(self.ips[self._bd_dof])
+        batch_size = gn.size(0) if batched else 0
+        lform = LinearForm(self.space, batch_size=batch_size)
+        lform.add_integrator(
+            ScalarBoundarySourceIntegrator(gn_source, zero_integral=True, batched=batched)
+        )
+        b_ = lform.assembly()
+        unsqueezed = False
+
+        if b_.ndim == 1:
+            b_ = b_.unsqueeze(0)
+            unsqueezed = True
+
+        NUM = b_.size(0)
+        ZERO = torch.zeros((NUM, 1), dtype=b_.dtype, device=b_.device)
+        b_ = torch.cat([b_, ZERO], dim=1)
+        uh = lu_solve(self._A_n_lu, self.pivots_n, b_, left=False)[:, :-1]
+
+        if unsqueezed:
+            uh = uh.squeeze(0)
+
+        return uh[..., self._bd_dof], gn
+
+    def label(self):
+        mesh = self.space.mesh
+        node = mesh.entity('node')
+        return self.levelset(node) < 0.

--- a/app/eit/data_generator.py
+++ b/app/eit/data_generator.py
@@ -120,7 +120,7 @@ class EITDataGenerator():
 
         return gn
 
-    def run(self) -> Tensor:
+    def run(self, return_full=False) -> Tensor:
         """_summary_
 
         Returns:
@@ -132,4 +132,6 @@ class EITDataGenerator():
         if self.unsqueezed:
             uh = uh.squeeze(0)
 
+        if return_full:
+            return uh
         return uh[..., self._bd_dof.cpu()]

--- a/app/eit/generate_e63_c8_v.yaml
+++ b/app/eit/generate_e63_c8_v.yaml
@@ -1,0 +1,14 @@
+
+head: 0
+tail: 2000
+
+data:
+  sigma: [10., 1.]
+  ext: 63
+  num_cir: 3
+  freq: [1, 2, 3, 4, 5, 6, 8, 16]
+  dtype: 'float64'
+  device: 'cuda:0'
+
+process_num: 4
+output_folder: 'D://data/gdgn_cir3_e64_64_c8_validate/'

--- a/app/eit/test_data_generator.py
+++ b/app/eit/test_data_generator.py
@@ -1,0 +1,65 @@
+"""An example generating a single data for EIT."""
+
+import torch
+from torch import Tensor, tensordot, rand
+import numpy as np
+from matplotlib import pyplot as plt
+
+from fealpy.torch.mesh import TriangleMesh
+from fealpy.mesh import TriangleMesh as TMD
+from data_generator import EITDataGenerator
+
+seed = 2024
+kwargs = {"dtype": torch.float64, "device": 'cpu'}
+NUM_CIR = 3
+SIGMA = [10., 1.]
+FREQ = [1, 2, 3, 4, 5, 6, 8, 16]
+EXT = 63
+
+
+def levelset(p: Tensor, centers: Tensor, radius: Tensor):
+    """
+    Calculate level set function value.
+    """
+    struct = p.shape[:-1]
+    p = p.reshape(-1, p.shape[-1])
+    dis = torch.norm(p[:, None, :] - centers[None, :, :], dim=-1) # (N, NCir)
+    ret, _ = torch.min(dis - radius[None, :], dim=-1) # (N, )
+    return ret.reshape(struct)
+
+def neumann(points: Tensor):
+    x = points[..., 0]
+    y = points[..., 1]
+    kwargs = {'dtype': points.dtype, "device": points.device}
+    theta = torch.arctan2(y, x)
+    freq = torch.tensor(FREQ, **kwargs)
+    return torch.cos(tensordot(freq, theta, dims=0))
+
+torch.manual_seed(seed)
+mesh = TriangleMesh.from_box((-1, 1, -1, 1), EXT, EXT, ftype=torch.float64, device='cpu')
+generator = EITDataGenerator(mesh=mesh)
+gn = generator.set_boundary(neumann, batched=True)
+
+ctrs = rand(NUM_CIR, 2, **kwargs) * 1.6 - 0.8 # (NCir, GD)
+b, _ = torch.min(0.9-torch.abs(ctrs), axis=-1) # (NCir, )
+rads = rand(NUM_CIR, **kwargs) * (b-0.1) + 0.1 # (NCir, )
+ls_fn = lambda p: levelset(p, ctrs, rads)
+
+label = generator.set_levelset(SIGMA, ls_fn)
+uh = generator.run(return_full=True)
+
+
+### visualize
+
+fig = plt.figure(figsize=(12, 6))
+fig.tight_layout()
+fig.suptitle('Parallel solving Poisson equation on 2D Triangle mesh')
+mesh_numpy = TMD.from_box((-1, 1, -1, 1), EXT, EXT)
+value = generator.space.value(uh, torch.tensor([[1/3, 1/3, 1/3]], device='cpu', dtype=torch.float64)).squeeze(0)
+value = value.cpu().numpy()
+
+for i in range(8):
+    axes = fig.add_subplot(2, 4, i+1)
+    mesh_numpy.add_plot(axes, cellcolor=value[i, :], cmap='jet', linewidths=0, showaxis=True)
+
+plt.show()

--- a/example/torch/poisson_tri_neumannbc_2d.py
+++ b/example/torch/poisson_tri_neumannbc_2d.py
@@ -20,7 +20,7 @@ from fealpy.ml import timer
 from matplotlib import pyplot as plt
 
 device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-NX, NY = 32, 32
+NX, NY = 64, 64
 
 
 def neumann(points: Tensor):
@@ -29,7 +29,7 @@ def neumann(points: Tensor):
     kwargs = {'dtype': points.dtype, "device": points.device}
     theta = torch.arctan2(y-0.5, x-0.5)
     freq = torch.arange(1, 11, **kwargs)
-    return cos(tensordot(freq, theta, dims=0))
+    return torch.sin(tensordot(freq, theta, dims=0))
 
 
 tmr = timer()
@@ -52,7 +52,7 @@ bform = BilinearForm(space)
 bform.add_integrator(ScalarDiffusionIntegrator())
 
 lform = LinearForm(space, batch_size=10)
-lform.add_integrator(ScalarBoundarySourceIntegrator(neumann, batched=True))
+lform.add_integrator(ScalarBoundarySourceIntegrator(neumann, zero_integral=True, batched=True))
 tmr.send('forms')
 
 A = bform.assembly()

--- a/fealpy/torch/fem/bilinear_form.py
+++ b/fealpy/torch/fem/bilinear_form.py
@@ -36,7 +36,7 @@ class BilinearForm(Form[_FS]):
         )
 
         for group in self.integrators.keys():
-            group_tensor, e2dof = self.assembly_group(group, retain_ints)
+            group_tensor, e2dof = self._assembly_group(group, retain_ints)
             I = torch.broadcast_to(e2dof[:, :, None], size=group_tensor.shape)
             J = torch.broadcast_to(e2dof[:, None, :], size=group_tensor.shape)
             indices = torch.stack([I.ravel(), J.ravel()], dim=0)

--- a/fealpy/torch/fem/form.py
+++ b/fealpy/torch/fem/form.py
@@ -52,6 +52,12 @@ class Form(Generic[_FS]):
         return I
 
     def clear_memory(self, group: Optional[str]=None) -> None:
+        """Clear the cache of the form, including global output and group output.
+
+        Args:
+            group (Optional[str], optional): The name of integrator group to clear
+            the result from. Defaults to None. Clear all cache if `None`.
+        """
         if group is None:
             self.memory.clear()
         else:
@@ -64,9 +70,6 @@ class Form(Generic[_FS]):
         INTS = self.integrators[group]
         ct = INTS[0](self.space)
         etg = INTS[0].to_global_dof(self.space)
-
-        if not retain_ints:
-            INTS[0].clear()
 
         for int_ in INTS[1:]:
             new_ct = int_(self.space)
@@ -81,8 +84,6 @@ class Form(Generic[_FS]):
                 ct = ct + new_ct.unsqueeze(0)
             else:
                 ct = ct + new_ct
-            if not retain_ints:
-                int_.clear()
 
         if retain_ints:
             self.memory[group] = (ct, etg)

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -1,14 +1,26 @@
 
 from abc import ABCMeta, abstractmethod
-from typing import Union, Callable, Optional
+from typing import Union, Callable, Optional, Any
 
 from torch import Tensor
 
-from ..functionspace.space import FunctionSpace as _FunctionSpace
+from ..functionspace.space import FunctionSpace as _FS
 
 Index = Union[int, slice, Tensor]
 _S = slice(None)
 CoefLike = Union[float, int, Tensor, Callable[..., Tensor]]
+
+
+def enable_cache(meth: Callable[[Any, _FS], Tensor]) -> Callable[[Any, _FS], Tensor]:
+    def wrapper(self, space: _FS) -> Tensor:
+        if getattr(self, '_cache', None) is None:
+            self._cache = {}
+        _cache = self._cache
+        key = meth.__name__ + '_' + str(id(space))
+        if key not in _cache:
+            _cache[key] = meth(self, space)
+        return _cache[key]
+    return wrapper
 
 
 class Integrator(metaclass=ABCMeta):
@@ -19,7 +31,7 @@ class Integrator(metaclass=ABCMeta):
     def __init__(self, method='assembly') -> None:
         self._assembly = method
 
-    def __call__(self, space: _FunctionSpace) -> Tensor:
+    def __call__(self, space: _FS) -> Tensor:
         if hasattr(self, '_value') and self._value is not None:
             return self._value
         else:
@@ -31,33 +43,43 @@ class Integrator(metaclass=ABCMeta):
             return self._value
 
     @abstractmethod
-    def to_global_dof(self, space: _FunctionSpace) -> Tensor:
-        """@brief Return the relationship between the integral entities
+    def to_global_dof(self, space: _FS) -> Tensor:
+        """Return the relationship between the integral entities
         and the global dofs."""
         raise NotImplementedError
 
-    def clear(self):
-        """@brief Clear the cached value."""
+    def clear(self, space_level=True) -> None:
+        """Clear the cache of the integrators.
+
+        Args:
+            space_level (bool, optional): Whether to clear cache for space,
+            such as basis, entity measure and bc points. Defaults to False.
+            If `False`, only clear the cache of the integral result.
+        """
         self._value = None
+
+        if space_level:
+            if hasattr(self, '_cache'):
+                self._cache.clear()
 
 
 class CellOperatorIntegrator(Integrator):
-    def assembly(self, space: _FunctionSpace) -> Tensor:
+    def assembly(self, space: _FS) -> Tensor:
         raise NotImplementedError
 
 
 class FaceOperatorIntegrator(Integrator):
-    def assembly(self, space: _FunctionSpace) -> Tensor:
+    def assembly(self, space: _FS) -> Tensor:
         raise NotImplementedError
 
 
 class CellSourceIntegrator(Integrator):
-    def assembly(self, space: _FunctionSpace) -> Tensor:
+    def assembly(self, space: _FS) -> Tensor:
         raise NotImplementedError
 
 
 class FaceSourceIntegrator(Integrator):
-    def assembly(self, space: _FunctionSpace) -> Tensor:
+    def assembly(self, space: _FS) -> Tensor:
         raise NotImplementedError
 
 

--- a/fealpy/torch/fem/linear_form.py
+++ b/fealpy/torch/fem/linear_form.py
@@ -28,7 +28,7 @@ class LinearForm(Form[_FS]):
         space = self.space
         device = space.device
         gdof = space.number_of_global_dofs()
-        global_mat_shape = (gdof, gdof)
+        global_mat_shape = (gdof,)
         M = torch.sparse_coo_tensor(
             torch.empty((1, 0), dtype=space.itype, device=device),
             torch.empty((0,), dtype=space.ftype, device=device),
@@ -37,7 +37,7 @@ class LinearForm(Form[_FS]):
 
         for group in self.integrators.keys():
             group_tensor, e2dof = self._assembly_group(group, retain_ints)
-            indices = e2dof.ravel()
+            indices = e2dof.view(1, -1)
             M += torch.sparse_coo_tensor(indices, group_tensor.ravel(), size=global_mat_shape)
 
         return M

--- a/fealpy/torch/fem/linear_form.py
+++ b/fealpy/torch/fem/linear_form.py
@@ -55,7 +55,7 @@ class LinearForm(Form[_FS]):
         )
 
         for group in self.integrators.keys():
-            group_tensor, e2dof = self.assembly_group(group, retain_ints)
+            group_tensor, e2dof = self._assembly_group(group, retain_ints)
             NC = e2dof.size(0)
             local_mat_shape = (batch_size, NC, ldof)
 

--- a/fealpy/torch/fem/scalar_boundary_source_integrator.py
+++ b/fealpy/torch/fem/scalar_boundary_source_integrator.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from ..mesh import HomoMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
-from ..functional import linear_integral
+from ..functional import linear_integral, integral
 from .integrator import FaceSourceIntegrator, _S, Index, CoefLike
 
 # TODO: Support the threshold, process the index
@@ -14,10 +14,12 @@ class ScalarBoundarySourceIntegrator(FaceSourceIntegrator):
     r"""The boundary source integrator for function spaces based on homogeneous meshes."""
     def __init__(self, source: Optional[CoefLike]=None, q: int=3, *,
                  threshold: Optional[Callable[[Tensor], Tensor]]=None,
+                 zero_integral: bool=False,
                  batched: bool=False) -> None:
         super().__init__()
         self.f = source
         self.q = q
+        self.zero_integral = zero_integral
         self.batched = batched
 
     def to_global_dof(self, space: _FS) -> Tensor:
@@ -40,5 +42,11 @@ class ScalarBoundarySourceIntegrator(FaceSourceIntegrator):
         bcs, ws = qf.get_quadrature_points_and_weights()
         phi = space.basis(bcs, index=index, variable='x')
         val = process_coef_func(f, bcs=bcs, mesh=mesh, etype='face', index=index) # TODO: support normal derivative
+
+        if self.zero_integral:
+            if not isinstance(val, Tensor):
+                raise RuntimeError("The zero_integral option is only supported when the source is a tensor.")
+            val_int = integral(val, ws, fm/fm.sum())
+            val = val - val_int.reshape((-1,) + (1,) * (val.ndim - 1))
 
         return linear_integral(phi, ws, fm, val, batched=self.batched)

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -7,7 +7,7 @@ from ..mesh import HomoMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import bilinear_integral
-from .integrator import CellOperatorIntegrator, _S, Index, CoefLike
+from .integrator import CellOperatorIntegrator, _S, Index, CoefLike, enable_cache
 
 
 class ScalarDiffusionIntegrator(CellOperatorIntegrator):
@@ -23,11 +23,12 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         self.index = index
         self.batched = batched
 
+    @enable_cache
     def to_global_dof(self, space: _FS) -> Tensor:
         return space.cell_to_dof()[self.index]
 
-    def assembly(self, space: _FS) -> Tensor:
-        coef = self.coef
+    @enable_cache
+    def fetch(self, space: _FS) -> Tensor:
         q = self.q
         index = self.index
         mesh = getattr(space, 'mesh', None)
@@ -41,6 +42,12 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         qf = mesh.integrator(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         gphi = space.grad_basis(bcs, index=index, variable='x')
+        return bcs, ws, gphi, cm, index
+
+    def assembly(self, space: _FS) -> Tensor:
+        coef = self.coef
+        mesh = getattr(space, 'mesh', None)
+        bcs, ws, gphi, cm, index = self.fetch(space)
         coef = process_coef_func(coef, bcs=bcs, mesh=mesh, etype='cell', index=index)
 
         return bilinear_integral(gphi, gphi, ws, cm, coef, batched=self.batched)

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -41,6 +41,6 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         qf = mesh.integrator(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         gphi = space.grad_basis(bcs, index=index, variable='x')
-        coef = process_coef_func(coef, mesh=mesh, etype='cell', index=index)
+        coef = process_coef_func(coef, bcs=bcs, mesh=mesh, etype='cell', index=index)
 
         return bilinear_integral(gphi, gphi, ws, cm, coef, batched=self.batched)

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -11,6 +11,20 @@ Number = Union[builtins.int, builtins.float]
 CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
 
 
+def integral(value: Tensor, weights: Tensor, measure: Tensor) -> Tensor:
+    """Numerical integration.
+
+    Args:
+        value (Tensor[..., Q, C]): The values on the quadrature points to be integrated.
+        weights (Tensor): The weights of the quadrature points.
+        measure (Tensor): The measure of the quadrature points.
+
+    Returns:
+        Tensor[...]: The result of the integration.
+    """
+    return einsum(f'q, c, ...qc -> ...', weights, measure, value)
+
+
 def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
                     coef: Union[Number, Tensor, None]=None,
                     batched: bool=False) -> Tensor:
@@ -42,7 +56,7 @@ def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
         return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
     else:
-        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")
+        raise TypeError(f"coef should be int, float or Tensor, but got {type(coef)}.")
 
 
 def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: Tensor,
@@ -77,4 +91,4 @@ def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: 
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
         return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
     else:
-        raise TypeError(f"coef should be int, float, Tensor or callable, but got {type(coef)}.")
+        raise TypeError(f"coef should be int, float or Tensor, but got {type(coef)}.")

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -281,7 +281,7 @@ class Mesh():
     def multi_index_matrix(self, p: int, etype: int) -> Tensor:
         return F.multi_index_matrix(p, etype, dtype=self.ds.itype, device=self.device)
 
-    def count(self) -> int: return self.ds.count()
+    def count(self, etype: Union[int, str]) -> int: return self.ds.count(etype)
     def number_of_cells(self) -> int: return self.ds.number_of_cells()
     def number_of_faces(self) -> int: return self.ds.number_of_faces()
     def number_of_edges(self) -> int: return self.ds.number_of_edges()

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -1,5 +1,4 @@
 
-from math import comb
 from typing import (
     Union, Optional, Dict, Sequence, overload, Callable,
     Literal, TypeVar
@@ -140,10 +139,20 @@ class MeshDataStructure():
     def device(self) -> _device: return self.cell.device
 
     ### counters
-    number_of_nodes: _int_func = lambda self: self.NN
-    number_of_edges: _int_func = lambda self: len(entity_dim2tensor(self, 1))
-    number_of_faces: _int_func = lambda self: len(entity_dim2tensor(self, self.top_dimension() - 1))
-    number_of_cells: _int_func = lambda self: len(entity_dim2tensor(self, self.top_dimension()))
+    def count(self, etype: Union[int, str]) -> int:
+        """@brief Return the number of entities of the given type."""
+        if etype in ('node', 0):
+            return self.NN
+        if isinstance(etype, str):
+            edim = entity_str2dim(self, etype)
+        if -edim in self._entity_storage: # for polygon mesh
+            return self._entity_storage[-edim].size(0) - 1
+        return entity_dim2tensor(self, edim).size(0) # for homogeneous mesh
+
+    def number_of_nodes(self): return self.NN
+    def number_of_edges(self): return self.count('edge')
+    def number_of_faces(self): return self.count('face')
+    def number_of_cells(self): return self.count('cell')
 
     ### constructors
     def construct(self) -> None:
@@ -272,6 +281,7 @@ class Mesh():
     def multi_index_matrix(self, p: int, etype: int) -> Tensor:
         return F.multi_index_matrix(p, etype, dtype=self.ds.itype, device=self.device)
 
+    def count(self) -> int: return self.ds.count()
     def number_of_cells(self) -> int: return self.ds.number_of_cells()
     def number_of_faces(self) -> int: return self.ds.number_of_faces()
     def number_of_edges(self) -> int: return self.ds.number_of_edges()


### PR DESCRIPTION
### New
- Setup the EIT app: add an EIT data generator and a script based on fealpy.torch. (NOTE: EIT models can predict inclusion distribution correctly on the data generated by this new generator.)
- Add `from_box` class method for TriangleMesh.

### Update
- ScalarBoundarySourceIntegrator now supports `zero_integral` option to make neumann bc zero-integral on the boundary if needed. Defaults to `False`.
- Fix bug in mesh entity counters.