### PR TITLE
update Torch module

### DIFF
--- a/app/eit/data_generator.py
+++ b/app/eit/data_generator.py
@@ -40,8 +40,9 @@ class EITDataGenerator():
         self._di = ScalarDiffusionIntegrator(None)
 
         # prepare for the unique condition in the neumann case
+        bd_dof = space.is_boundary_dof().nonzero().ravel()
         gdof = space.number_of_global_dofs()
-        zeros = torch.zeros((gdof, ), **kwargs)
+        zeros = torch.zeros_like(bd_dof, **kwargs)
         lform_c = LinearForm(space)
         lform_c.add_integrator(ScalarBoundarySourceIntegrator(1.))
         cdata = lform_c.assembly(return_dense=False)
@@ -150,4 +151,4 @@ class EITDataGenerator():
 
         # NOTE: interpolation points on nodes are arranged firstly,
         # therefore the value on the boundary nodes can be fetched like this:
-        return uh[..., self._bd_node_index]
+        return uh[..., self._bd_node_index.cpu()]

--- a/app/eit/test_data_generator.py
+++ b/app/eit/test_data_generator.py
@@ -1,8 +1,11 @@
-"""An example generating a single data for EIT."""
+"""An example generating a single data for EIT.
+
+This can only test if the generator can solve the PDE, but can not test if
+the gd and gn saved are correct.
+"""
 
 import torch
 from torch import Tensor, tensordot, rand
-import numpy as np
 from matplotlib import pyplot as plt
 
 from fealpy.torch.mesh import TriangleMesh

--- a/example/torch/poisson_tri_dirichletbc_2d.py
+++ b/example/torch/poisson_tri_dirichletbc_2d.py
@@ -62,15 +62,13 @@ tmr.send('forms')
 
 A = bform.assembly()
 F = lform.assembly()
-
-uh = torch.zeros((10, space.number_of_global_dofs()), dtype=torch.float64, device=device)
 tmr.send('assembly')
 
-A, F = DirichletBC(space, solution).apply(A, F, uh)
+A, F = DirichletBC(space).apply(A, F, gd=solution)
 tmr.send('dirichlet')
 
 A = A.to_sparse_csr()
-uh = sparse_cg(A, F, uh, maxiter=5000, batch_first=True)
+uh = sparse_cg(A, F, maxiter=5000, batch_first=True)
 uh = uh.detach()
 value = space.value(uh, torch.tensor([[1/3, 1/3, 1/3]], device=device, dtype=torch.float64)).squeeze(0)
 value = value.cpu().numpy()

--- a/example/torch/poisson_tri_dirichletbc_2d.py
+++ b/example/torch/poisson_tri_dirichletbc_2d.py
@@ -46,15 +46,9 @@ def solution(points: Tensor):
 tmr = timer()
 
 mesh_numpy = TMD.from_box(nx=NX, ny=NY)
-cell = mesh_numpy.ds.cell
-node = mesh_numpy.node
 next(tmr)
-mesh = TriangleMesh(
-    torch.from_numpy(node).to(device),
-    torch.from_numpy(cell).to(device),
-)
-NC = cell.shape[0]
-
+mesh = TriangleMesh.from_box(nx=NX, ny=NY, device=device)
+NC = mesh.number_of_cells()
 
 space = LagrangeFESpace(mesh, p=3)
 tmr.send('mesh_and_space')
@@ -80,8 +74,6 @@ uh = sparse_cg(A, F, uh, maxiter=5000, batch_first=True)
 uh = uh.detach()
 value = space.value(uh, torch.tensor([[1/3, 1/3, 1/3]], device=device, dtype=torch.float64)).squeeze(0)
 value = value.cpu().numpy()
-print(value.shape)
-# uh = uh.cpu().numpy()
 tmr.send('solve(cg)')
 tmr.send('stop')
 

--- a/example/torch/poisson_tri_neumannbc_2d.py
+++ b/example/torch/poisson_tri_neumannbc_2d.py
@@ -35,14 +35,9 @@ def neumann(points: Tensor):
 tmr = timer()
 
 mesh_numpy = TMD.from_box(nx=NX, ny=NY)
-cell = mesh_numpy.ds.cell
-node = mesh_numpy.node
 next(tmr)
-mesh = TriangleMesh(
-    torch.from_numpy(node).to(device),
-    torch.from_numpy(cell).to(device),
-)
-NC = cell.shape[0]
+mesh = TriangleMesh.from_box(nx=NX, ny=NY, device=device)
+NC = mesh.number_of_cells()
 
 
 space = LagrangeFESpace(mesh, p=1)
@@ -67,8 +62,6 @@ uh = sparse_cg(A, F, uh, maxiter=1000, batch_first=True)
 uh = uh.detach()
 value = space.value(uh, torch.tensor([[1/3, 1/3, 1/3]], device=device, dtype=torch.float64)).squeeze(0)
 value = value.cpu().numpy()
-print(value.shape)
-# uh = uh.cpu().numpy()
 tmr.send('solve(cg)')
 tmr.send('stop')
 

--- a/fealpy/torch/fem/dirichlet_bc.py
+++ b/fealpy/torch/fem/dirichlet_bc.py
@@ -10,59 +10,102 @@ from ..functionspace.space import FunctionSpace
 
 
 class DirichletBC():
-    """@brief"""
+    """Dirichlet boundary condition."""
     def __init__(self, space: FunctionSpace, gD: Union[Callable[..., Tensor], Tensor],
-                 threshold: Optional[Callable]=None,
-                 batch_first: bool=True):
+                 *, threshold: Optional[Callable]=None, left: bool=True):
         self.space = space
         self.gD = gD
         self.threshold = threshold
-        self.batch_first = batch_first
+        self.left = left
         self.bctype = 'Dirichlet'
 
-    def apply(self, A: Tensor, f: Tensor, uh: Tensor) -> Tuple[Tensor, Tensor]:
-        """
-        @brief Process Dirichlet boundary condition. This is out-of-place for
-        A and f, while in-place for uh.
-
-        @param[in] A: coefficient matrix
-        @param[in] f: right-hand-size vector
-        @param[in] uh: boundary-interpolated solution vector
-
-        @Returns:
-            A: coefficient matrix
-            f: right-hand-size vector
-        """
-        return self.apply_for_other_space(A, f, uh)
-
-    # TODO: finish this
-    def apply_for_other_space(self, A: Tensor, f: Tensor, uh: Tensor) -> Tuple[Tensor, Tensor]:
-        """@brief 处理基是向量函数的向量函数空间或标量函数空间的 Dirichlet 边界条件"""
-        # Make sure that A is in the COO format and f is dense.
-        if not A.layout == torch.sparse_coo:
-            raise ValueError('The layout of A must be torch.sparse_coo.')
-        if not A.is_coalesced():
-            raise RuntimeError('The A must be coalesced.')
-        if f.is_sparse:
-            raise ValueError('The layout of f must be torch.dense.')
-
-        space = self.space
-        gD = self.gD
         isDDof = space.is_boundary_dof(threshold=self.threshold) # on the same device as space
-        DIM = -1 if self.batch_first else 0
-        space.interpolate(gD, uh, dim=DIM, index=isDDof) # isDDof.shape == uh.shape
+        self.is_boundary_dof = isDDof
+        self.boundary_dof_index = torch.nonzero(isDDof, as_tuple=True)[0]
+        self.gdof = space.number_of_global_dofs()
 
-        if self.batch_first:
-            uh = uh.transpose(0, 1)
-            f = f.transpose(0, 1)
+    def check_matrix(self, matrix: Tensor, /) -> Tensor:
+        """Check if the input matrix is available for Dirichlet boundary condition.
 
-        if uh.ndim == 1:
-            f = f - mm(A, uh.unsqueeze(-1)).squeeze(-1)
-        elif uh.ndim == 2:
-            f = f - mm(A, uh)
+        Args:
+            matrix (Tensor): The left-hand-side matrix of the linear system.
+
+        Raises:
+            ValueError: When the layout is not torch.sparse_coo.
+            RuntimeError: When the matrix is not coalesced.
+            ValueError: When the matrix is not 2-dimensional.
+            ValueError: When the matrix is not square.
+            ValueError: When the matrix size does not match the gdof of the space.
+
+        Returns:
+            Tensor: The input matrix object.
+        """
+        if not matrix.layout == torch.sparse_coo:
+            raise ValueError('The layout of matrix must be torch.sparse_coo.')
+        if not matrix.is_coalesced():
+            raise RuntimeError('The matrix must be coalesced.')
+        if len(matrix.shape) != 2:
+            raise ValueError('The matrix must be a 2-D sparse COO matrix.')
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError('The matrix must be a square matrix.')
+        if matrix.shape[0] != self.gdof:
+            raise ValueError('The matrix size must match the gdof of the space.')
+        return matrix
+
+    def check_vector(self, vector: Tensor, /) -> Tensor:
+        """Check if the input vector is available for Dirichlet boundary conditions.
+
+        Args:
+            vector (Tensor): The right-hand-side vector of the linear system.
+
+        Raises:
+            ValueError: _description_
+            ValueError: _description_
+            ValueError: _description_
+            ValueError: _description_
+
+        Returns:
+            Tensor: The input vector object.
+        """
+        if vector.is_sparse:
+            raise ValueError('The layout of vector must be torch.dense.')
+        if vector.ndim not in (1, 2):
+            raise ValueError('The vector must be 1-D or 2-D.')
+        if self.left:
+            if vector.shape[1] != self.gdof:
+                raise ValueError('The vector size must match the gdof of the space.')
         else:
-            raise ValueError('The dimension of uh must be 1 or 2.')
+            if vector.shape[0] != self.gdof:
+                raise ValueError('The vector size must match the gdof of the space.')
+        return vector
 
+    def apply(self, A: Tensor, f: Tensor, uh: Tensor, *, check=True) -> Tuple[Tensor, Tensor]:
+        """Apply Dirichlet boundary conditions.
+
+        Args:
+            A (Tensor): _description_
+            f (Tensor): _description_
+            uh (Tensor): _description_
+            check (bool, optional): _description_. Defaults to True.
+
+        Returns:
+            Tuple[Tensor, Tensor]: _description_
+        """
+        f = self.apply_vector(f, A, uh, check=check)
+        A = self.apply_matrix(A, check=check)
+        return A, f
+
+    def apply_matrix(self, matrix: Tensor, *, check=True) -> Tensor:
+        """Apply Dirichlet boundary condition to left-hand-size matrix only.
+
+        Args:
+            matrix (Tensor): The original left-hand-size COO sparse matrix\
+                of the linear system.
+            check (bool, optional): Whether to check the matrix. Defaults to True.
+
+        Returns:
+            Tensor: New adjusted left-hand-size COO matrix.
+        """
         # NOTE: Code in the numpy version:
         # ```
         # bdIdx = np.zeros(A.shape[0], dtype=np.int_)
@@ -71,7 +114,9 @@ class DirichletBC():
         # D1 = spdiags(bdIdx, 0, A.shape[0], A.shape[0])
         # A = D0@A@D0 + D1
         # ```
-
+        # Here the adjustment is done by operating the sparse structure directly.
+        isDDof = self.is_boundary_dof
+        A = self.check_matrix(matrix) if check else matrix
         new_values = torch.zeros_like(A.values(), requires_grad=False)
         indices = A.indices()
         IDX = isDDof[indices[0, :]] & (indices[1, :] == indices[0, :])
@@ -81,16 +126,47 @@ class DirichletBC():
         A = torch.sparse_coo_tensor(indices, new_values, A.size())
         A = A.coalesce()
 
-        bdIdx = torch.zeros_like(isDDof, requires_grad=False)
-        bdIdx[isDDof.reshape(-1)] = True
-        if uh.ndim == 2:
-            bdIdx = bdIdx.unsqueeze_(1)
-        f = f * ~bdIdx + uh * bdIdx
+        return A
 
-        if self.batch_first:
-            f = f.transpose(0, 1)
+    def apply_vector(self, vector: Tensor, matrix: Tensor, uh: Optional[Tensor],
+                     *, check=True) -> Tensor:
+        """Appy Dirichlet boundary contition to right-hand-size vector only.
 
-        return A, f
+        Args:
+            vector (Tensor): The original right-hand-size vector.
+            matrix (Tensor): The original COO sparse matrix.
+            uh (Optional[Tensor]): The solution uh Tensor. Defuault to None.
+            check (bool, optional): Whether to check the vector. Defaults to True.
+
+        Returns:
+            Tensor: New adjusted right-hand-size vector.
+        """
+        A = matrix
+        f = self.check_vector(vector) if check else vector
+        bd_idx = self.boundary_dof_index
+        DIM = -1 if self.left else 0
+
+        if uh is None:
+            uh = torch.zeros_like(f)
+        self.space.interpolate(self.gD, uh, dim=DIM, index=bd_idx) # isDDof.shape == uh.shape
+
+        if uh.ndim == 1:
+            f = f - mm(A, uh.unsqueeze(-1)).squeeze(-1)
+            f[bd_idx] = uh[bd_idx]
+
+        elif uh.ndim == 2:
+            if self.left:
+                uh = uh.transpose(0, 1)
+                f = f.transpose(0, 1)
+            f = f - mm(A, uh)
+            f[bd_idx] = uh[bd_idx]
+            if self.left:
+                f = f.transpose(0, 1)
+        else:
+            raise ValueError('The dimension of uh must be 1 or 2.')
+
+        return f
+
 
     # def apply_for_vspace_with_scalar_basis(self, A, f, uh, dflag=None):
     #     """

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -48,17 +48,17 @@ class Integrator(metaclass=ABCMeta):
         and the global dofs."""
         raise NotImplementedError
 
-    def clear(self, space_level=True) -> None:
+    def clear(self, result_only=True) -> None:
         """Clear the cache of the integrators.
 
         Args:
-            space_level (bool, optional): Whether to clear cache for space,
-            such as basis, entity measure and bc points. Defaults to False.
-            If `False`, only clear the cache of the integral result.
+            result_only (bool, optional): Whether to only clear the cached result.
+            Other cache may be basis, entity measures, bc points... Defaults to True.
+            If `False`, anything cached will be cleared.
         """
         self._value = None
 
-        if space_level:
+        if not result_only:
             if hasattr(self, '_cache'):
                 self._cache.clear()
 

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -11,18 +11,22 @@ Number = Union[builtins.int, builtins.float]
 CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
 
 
-def integral(value: Tensor, weights: Tensor, measure: Tensor) -> Tensor:
+def integral(value: Tensor, weights: Tensor, measure: Tensor, *,
+             cell_type=False) -> Tensor:
     """Numerical integration.
 
     Args:
         value (Tensor[..., Q, C]): The values on the quadrature points to be integrated.
-        weights (Tensor): The weights of the quadrature points.
-        measure (Tensor): The measure of the quadrature points.
+        weights (Tensor[Q,]): The weights of the quadrature points.
+        measure (Tensor[C,]): The measure of the quadrature points.
+        cell_type (bool): Whether to return integration in each cell. Defaults to False.
 
     Returns:
-        Tensor[...]: The result of the integration.
+        Tensor[...]: The result of the integration. The shape will be [..., C]\
+        if cell_type is True, otherwise [...].
     """
-    return einsum(f'q, c, ...qc -> ...', weights, measure, value)
+    subs = '...c' if cell_type else '...'
+    return einsum(f'q, c, ...qc -> {subs}', weights, measure, value)
 
 
 def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -12,20 +12,20 @@ CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
 
 
 def integral(value: Tensor, weights: Tensor, measure: Tensor, *,
-             cell_type=False) -> Tensor:
+             entity_type=False) -> Tensor:
     """Numerical integration.
 
     Args:
         value (Tensor[..., Q, C]): The values on the quadrature points to be integrated.
         weights (Tensor[Q,]): The weights of the quadrature points.
         measure (Tensor[C,]): The measure of the quadrature points.
-        cell_type (bool): Whether to return integration in each cell. Defaults to False.
+        entity_type (bool): Whether to return integration in each entity. Defaults to False.
 
     Returns:
         Tensor[...]: The result of the integration. The shape will be [..., C]\
-        if cell_type is True, otherwise [...].
+        if entity_type is True, otherwise [...].
     """
-    subs = '...c' if cell_type else '...'
+    subs = '...c' if entity_type else '...'
     return einsum(f'q, c, ...qc -> {subs}', weights, measure, value)
 
 

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -218,8 +218,47 @@ class MeshDataStructure():
             return face2cell[index]
 
     ### boundary
-    def boundary_face_flag(self): return self.face2cell[:, 0] == self.face2cell[:, 1]
-    def boundary_face_index(self): return torch.nonzero(self.boundary_face_flag(), as_tuple=True)[0]
+    def boundary_node_flag(self) -> Tensor:
+        """Return a boolean tensor indicating the boundary nodes.
+
+        Returns:
+            Tensor: boundary node flag.
+        """
+        NN = self.number_of_nodes()
+        bd_face_flag = self.boundary_face_flag()
+        kwargs = {'dtype': bd_face_flag.dtype, 'device': bd_face_flag.device}
+        bd_face2node = self.entity('face', index=bd_face_flag)
+        bd_node_flag = torch.zeros((NN,), **kwargs)
+        bd_node_flag[bd_face2node.ravel()] = True
+        return bd_node_flag
+
+    def boundary_face_flag(self) -> Tensor:
+        """Return a boolean tensor indicating the boundary faces.
+
+        Returns:
+            Tensor: boundary face flag.
+        """
+        return self.face2cell[:, 0] == self.face2cell[:, 1]
+
+    def boundary_cell_flag(self) -> Tensor:
+        """Return a boolean tensor indicating the boundary cells.
+
+        Returns:
+            Tensor: boundary cell flag.
+        """
+        NC = self.number_of_cells()
+        bd_face_flag = self.boundary_face_flag()
+        kwargs = {'dtype': bd_face_flag.dtype, 'device': bd_face_flag.device}
+        bd_face2cell = self.face2cell[bd_face_flag, 0]
+        bd_cell_flag = torch.zeros((NC,), **kwargs)
+        bd_cell_flag[bd_face2cell.ravel()] = True
+        return bd_cell_flag
+
+    def boundary_node_index(self): return self.boundary_node_flag().nonzero().ravel()
+    # TODO: finish this:
+    # def boundary_edge_index(self): return self.boundary_edge_flag().nonzero().ravel()
+    def boundary_face_index(self): return self.boundary_face_flag().nonzero().ravel()
+    def boundary_cell_index(self): return self.boundary_cell_flag().nonzero().ravel()
 
 
 class HomoMeshDataStructure(MeshDataStructure):

--- a/fealpy/torch/solver/cg.py
+++ b/fealpy/torch/solver/cg.py
@@ -38,7 +38,8 @@ def sparse_cg(A: Tensor, b: Tensor, x0: Optional[Tensor]=None, *,
     """
     assert isinstance(A, Tensor), "A must be a torch.Tensor"
     assert isinstance(b, Tensor), "b must be a torch.Tensor"
-    assert isinstance(x0, Tensor), "x0 must be a torch.Tensor"
+    if x0 is not None:
+        assert isinstance(x0, Tensor), "x0 must be a torch.Tensor if not None"
     unsqueezed = False
 
     if not (A.is_sparse_csr or A.is_sparse):

--- a/fealpy/torch/solver/cg.py
+++ b/fealpy/torch/solver/cg.py
@@ -82,8 +82,10 @@ class SparseCG(Function):
     @staticmethod
     def forward(A, b, x0, atol, rtol, maxiter):
         # initialize
-        x = x0                 # (dof, batch)
-        r = b - mm(A, x0)      # (dof, batch)
+        A = A.detach()
+        b = b.detach()
+        x = x0.detach()        # (dof, batch)
+        r = b - mm(A, x)       # (dof, batch)
         p = r                  # (dof, batch)
         n_iter = 0
         b_norm = b.norm()
@@ -152,5 +154,6 @@ class SparseCG(Function):
         if ctx.needs_input_grad[1]:
             weights = grad_output.mean(dim=-1, keepdim=True)
             grad_b = mm(inv_A, weights)
+            grad_b = torch.broadcast_to(grad_b, x.shape)
 
         return grad_A, grad_b, None, None, None, None


### PR DESCRIPTION
### New
- Add boundary node/cell index/flag in mesh base class.

### Update
- DirichletBC now can apply to matrix and vector separately by `apply_matrix` and `apply_vector`.
- DirichletBC: `gd` is optional in `__init__`, and can be provided when calling `apply` or `apply_vector`.
- update the EIT data generator.
- add `entity_type` option to the `integral` function in torch/functional.py.
- Change the cache clear option `space_level` in Integrator.clear() to `result_only`.