### PR TITLE
update the Torch module

### DIFF
--- a/app/eit/data_generator.py
+++ b/app/eit/data_generator.py
@@ -83,8 +83,7 @@ class EITDataGenerator():
         space = self.space
 
         bform = BilinearForm(space)
-        self._di.coef = _coef_func
-        self._di.clear(result_only=True)
+        self._di.set_coef(_coef_func)
         bform.add_integrator(self._di)
         self._A = bform.assembly()
         A_n = cat([cat([self._A, self.c], dim=1),
@@ -114,9 +113,8 @@ class EITDataGenerator():
         gn = gn_source(self.bd_node)
         batch_size = gn.size(0) if batched else 0
         lform = LinearForm(self.space, batch_size=batch_size)
-        self._bsi.f = gn_source
+        self._bsi.set_source(gn_source)
         self._bsi.batched = batched
-        self._bsi.clear(result_only=True)
         lform.add_integrator(self._bsi)
         b_ = lform.assembly()
         self.unsqueezed = False

--- a/fealpy/torch/fem/dirichlet_bc.py
+++ b/fealpy/torch/fem/dirichlet_bc.py
@@ -137,7 +137,7 @@ class DirichletBC():
 
         return A
 
-    def apply_vector(self, vector: Tensor, matrix: Tensor, uh: Optional[Tensor],
+    def apply_vector(self, vector: Tensor, matrix: Tensor, uh: Optional[Tensor]=None,
                      gd: Optional[CoefLike]=None, *, check=True) -> Tensor:
         """Appy Dirichlet boundary contition to right-hand-size vector only.
 

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -7,7 +7,6 @@ from torch import Tensor
 from ..functionspace.space import FunctionSpace as _FS
 
 Index = Union[int, slice, Tensor]
-_S = slice(None)
 CoefLike = Union[float, int, Tensor, Callable[..., Tensor]]
 _Meth = TypeVar('_Meth', bound=Callable[..., Any])
 
@@ -64,28 +63,58 @@ class Integrator(metaclass=ABCMeta):
                 self._cache.clear()
 
 
+class OperatorIntegrator(Integrator):
+    coef: Optional[CoefLike]
+
+    def assembly(self, space: _FS) -> Tensor:
+        raise NotImplementedError
+
+    def set_coef(self, coef: Optional[CoefLike]=None, /) -> None:
+        """Set a new coefficient of the equation to the integrator.
+
+        Args:
+            coef (CoefLike | None, optional): Tensor function or Tensor. Defaults to None.
+        """
+        self.coef = coef
+        self.clear()
+
+
+class SourceIntegrator(Integrator):
+    source: Optional[CoefLike]
+
+    def assembly(self, space: _FS) -> Tensor:
+        raise NotImplementedError
+
+    def set_source(self, source: Optional[CoefLike]=None, /) -> None:
+        """Set a new source term of the equation to the integrator.
+
+        Args:
+            source (CoefLike | None, optional): Tensor function or Tensor. Defaults to None.
+        """
+        self.source = source
+        self.clear()
+
+
+# These Integrator classes are for type checking
+
 class CellOperatorIntegrator(Integrator):
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
-
-
-class FaceOperatorIntegrator(Integrator):
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
-
+    pass
 
 class CellSourceIntegrator(Integrator):
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
+    pass
 
+class FaceOperatorIntegrator(Integrator):
+    pass
 
 class FaceSourceIntegrator(Integrator):
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
+    pass
 
 
 __all__ = [
     'Integrator',
+    'OperatorIntegrator',
+    'SourceIntegrator',
+
     'CellOperatorIntegrator',
     'FaceOperatorIntegrator',
     'CellSourceIntegrator',

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -71,6 +71,7 @@ class OperatorIntegrator(Integrator):
 
     def set_coef(self, coef: Optional[CoefLike]=None, /) -> None:
         """Set a new coefficient of the equation to the integrator.
+        This will clear the cached result.
 
         Args:
             coef (CoefLike | None, optional): Tensor function or Tensor. Defaults to None.
@@ -87,6 +88,7 @@ class SourceIntegrator(Integrator):
 
     def set_source(self, source: Optional[CoefLike]=None, /) -> None:
         """Set a new source term of the equation to the integrator.
+        This will clear the cached result.
 
         Args:
             source (CoefLike | None, optional): Tensor function or Tensor. Defaults to None.
@@ -97,16 +99,16 @@ class SourceIntegrator(Integrator):
 
 # These Integrator classes are for type checking
 
-class CellOperatorIntegrator(Integrator):
+class CellOperatorIntegrator(OperatorIntegrator):
     pass
 
-class CellSourceIntegrator(Integrator):
+class CellSourceIntegrator(SourceIntegrator):
     pass
 
-class FaceOperatorIntegrator(Integrator):
+class FaceOperatorIntegrator(OperatorIntegrator):
     pass
 
-class FaceSourceIntegrator(Integrator):
+class FaceSourceIntegrator(SourceIntegrator):
     pass
 
 

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -1,6 +1,6 @@
 
 from abc import ABCMeta, abstractmethod
-from typing import Union, Callable, Optional, Any
+from typing import Union, Callable, Optional, Any, TypeVar
 
 from torch import Tensor
 
@@ -9,9 +9,10 @@ from ..functionspace.space import FunctionSpace as _FS
 Index = Union[int, slice, Tensor]
 _S = slice(None)
 CoefLike = Union[float, int, Tensor, Callable[..., Tensor]]
+_Meth = TypeVar('_Meth', bound=Callable[..., Any])
 
 
-def enable_cache(meth: Callable[[Any, _FS], Tensor]) -> Callable[[Any, _FS], Tensor]:
+def enable_cache(meth: _Meth) -> _Meth:
     def wrapper(self, space: _FS) -> Tensor:
         if getattr(self, '_cache', None) is None:
             self._cache = {}

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -12,13 +12,13 @@ from .integrator import CellOperatorIntegrator, _S, Index, CoefLike, enable_cach
 
 class ScalarDiffusionIntegrator(CellOperatorIntegrator):
     r"""The diffusion integrator for function spaces based on homogeneous meshes."""
-    def __init__(self, c: Optional[CoefLike]=None, q: int=3, *,
+    def __init__(self, coef: Optional[CoefLike]=None, q: int=3, *,
                  index: Index=_S,
                  batched: bool=False,
                  method: Optional[str]=None) -> None:
         method = 'assembly' if (method is None) else method
         super().__init__(method=method)
-        self.coef = c
+        self.coef = coef
         self.q = q
         self.index = index
         self.batched = batched
@@ -55,7 +55,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
     def fast_assembly(self, space: _FS) -> Tensor:
         """
         限制：常系数、单纯形网格
-        TODO: 加入 assert 
+        TODO: 加入 assert
         """
         mesh = getattr(space, 'mesh', None)
         bcs, ws, gphi, cm, index = self.fetch(space, variable='u')

--- a/fealpy/torch/fem/scalar_source_integrator.py
+++ b/fealpy/torch/fem/scalar_source_integrator.py
@@ -7,7 +7,7 @@ from ..mesh import HomoMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import linear_integral
-from .integrator import CellSourceIntegrator, _S, Index, CoefLike
+from .integrator import CellSourceIntegrator, _S, Index, CoefLike, enable_cache
 
 
 class ScalarSourceIntegrator(CellSourceIntegrator):
@@ -16,16 +16,17 @@ class ScalarSourceIntegrator(CellSourceIntegrator):
                  index: Index=_S,
                  batched: bool=False) -> None:
         super().__init__()
-        self.f = source
+        self.source = source
         self.q = q
         self.index = index
         self.batched = batched
 
+    @enable_cache
     def to_global_dof(self, space: _FS) -> Tensor:
         return space.cell_to_dof()[self.index]
 
-    def assembly(self, space: _FS) -> Tensor:
-        f = self.f
+    @enable_cache
+    def fetch(self, space: _FS):
         q = self.q
         index = self.index
         mesh = getattr(space, 'mesh', None)
@@ -39,6 +40,13 @@ class ScalarSourceIntegrator(CellSourceIntegrator):
         qf = mesh.integrator(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         phi = space.basis(bcs, index=index, variable='x')
+
+        return bcs, ws, phi, cm, index
+
+    def assembly(self, space: _FS) -> Tensor:
+        f = self.source
+        mesh = getattr(space, 'mesh', None)
+        bcs, ws, phi, cm, index = self.fetch(space)
         val = process_coef_func(f, bcs=bcs, mesh=mesh, etype='cell', index=index)
 
         return linear_integral(phi, ws, cm, val, batched=self.batched)

--- a/fealpy/torch/mesh/functional.py
+++ b/fealpy/torch/mesh/functional.py
@@ -56,12 +56,32 @@ def edge_length(points: Tensor, out=None) -> Tensor:
     r"""Edge length.
 
     Args:
-        points: Tensor(..., 2, GD).
+        points (Tensor): Coordinates of points in two ends of edges, shaped [..., 2, GD].
+        out (Tensor, optional): The output tensor. Defaults to None.
 
     Returns:
-        Tensor(...,).
+        Tensor: Length of edges, shaped [...].
     """
     return norm(points[..., 0, :] - points[..., 1, :], dim=-1, out=out)
+
+
+def edge_normal(points: Tensor, unit: bool=False, out=None) -> Tensor:
+    """Edge normal for 2D meshes.
+
+    Args:
+        points (Tensor): Coordinates of points in two ends of edges, shaped [..., 2, GD].
+        unit (bool, optional): Whether to normalize the normal. Defaults to False.
+        out (Tensor, optional): The output tensor. Defaults to None.
+
+    Returns:
+        Tensor: Normal of edges, shaped [..., GD].
+    """
+    if points.shape[-1] != 2:
+        raise ValueError("Only 2D meshes are supported.")
+    edges = points[..., 1, :] - points[..., 0, :]
+    if unit:
+        edges = edges.div_(norm(edges, dim=-1, keepdim=True))
+    return torch.cat([edges[..., 1], -edges[..., 0]], dim=-1, out=out)
 
 
 def entity_barycenter(etn: Tensor, node: Tensor) -> Tensor:

--- a/fealpy/torch/mesh/functional.py
+++ b/fealpy/torch/mesh/functional.py
@@ -81,7 +81,7 @@ def edge_normal(points: Tensor, unit: bool=False, out=None) -> Tensor:
     edges = points[..., 1, :] - points[..., 0, :]
     if unit:
         edges = edges.div_(norm(edges, dim=-1, keepdim=True))
-    return torch.cat([edges[..., 1], -edges[..., 0]], dim=-1, out=out)
+    return torch.stack([edges[..., 1], -edges[..., 0]], dim=-1, out=out)
 
 
 def entity_barycenter(etn: Tensor, node: Tensor) -> Tensor:

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -352,6 +352,39 @@ class Mesh():
         etn = entity_dim2node(self.ds, etype, index, dtype=node.dtype)
         return F.entity_barycenter(etn, node)
 
+    def edge_length(self, index: Index=_S, out=None) -> Tensor:
+        """Calculate the length of the edges.
+
+        Args:
+            index (int | slice | Tensor, optional): Index of edges.
+            out (Tensor, optional): The output tensor. Defaults to None.
+
+        Returns:
+            Tensor: Length of edges, shaped [NE,].
+        """
+        edge = self.entity(1, index=index)
+        return F.edge_length(self.node[edge], out=out)
+
+    def edge_normal(self, index: Index=_S, unit: bool=False, out=None) -> Tensor:
+        """Calculate the normal of the edges.
+
+        Args:
+            index (int | slice | Tensor, optional): Index of edges.
+            unit (bool, optional): _description_. Defaults to False.
+            out (Tensor, optional): _description_. Defaults to None.
+
+        Returns:
+            Tensor: _description_
+        """
+        edge = self.entity(1, index=index)
+        return F.edge_normal(self.node[edge], unit=unit, out=out)
+
+    def edge_unit_normal(self, index: Index=_S, out=None) -> Tensor:
+        """Calculate the unit normal of the edges.
+        Equivalent to `edge_normal(index=index, unit=True)`.
+        """
+        return self.edge_normal(index=index, unit=True, out=out)
+
     def integrator(self, q: int, etype: Union[int, str]='cell', qtype: str='legendre') -> Quadrature:
         """Get the quadrature points and weights."""
         raise NotImplementedError

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -140,7 +140,7 @@ class MeshDataStructure():
 
     ### counters
     def count(self, etype: Union[int, str]) -> int:
-        """@brief Return the number of entities of the given type."""
+        """Return the number of entities of the given type."""
         if etype in ('node', 0):
             return self.NN
         if isinstance(etype, str):
@@ -163,15 +163,19 @@ class MeshDataStructure():
     @overload
     def entity(self, etype: Union[int, str], index: Optional[Index]=None, *, default: _T) -> Union[Tensor, _T]: ...
     def entity(self, etype: Union[int, str], index: Optional[Index]=None, *, default=_default):
-        r"""@brief Get entities in mesh structure.
+        """Get entities in mesh structure.
 
-        @param etype: int or str. The topology dimension of the entity, or name
-        'cell' | 'face' | 'edge'. Note that 'node' is not in mesh structure.
-        For polygon meshes, the names 'cell_location' | 'face_location' may also be
-        available, and the `index` argument is applied on the flattened entity tensor.
-        @param index: int, slice ot Tensor. The index of the entity.
+        Args:
+            index (int | slice | Tensor): The index of the entity.
+            etype (int | str): The topology dimension of the entity, or name
+            'cell' | 'face' | 'edge'. Note that 'node' is not available in data structure.
+            For polygon meshes, the names 'cell_location' | 'face_location' may also be
+            available, and the `index` argument is applied on the flattened entity tensor.
+            index (int | slice | Tensor): The index of the entity.
+            default (Any): The default value if the entity is not found.
 
-        @return: Tensor or Sequence[Tensor].
+        Returns:
+            Tensor: Entity or the default value.
         """
         if isinstance(etype, str):
             etype = entity_str2dim(self, etype)
@@ -291,9 +295,6 @@ class HomoMeshDataStructure(MeshDataStructure):
         total_edge = cell[..., local_edge].reshape(-1, NVE)
         return total_edge
 
-    def construct(self) -> None:
-        raise NotImplementedError
-
 
 ##################################################
 ### Mesh Base
@@ -332,13 +333,15 @@ class Mesh():
             return self.ds.entity(etype, index)
 
     def entity_barycenter(self, etype: Union[int, str], index: Optional[Index]=None) -> Tensor:
-        r"""@brief Get the barycenter of the entity.
+        """Get the barycenter of the entity.
 
-        @param etype: int or str. The topology dimension of the entity, or name
-        'cell' | 'face' | 'edge' | 'node'. Returns sliced node if 'node'.
-        @param index: int, slice ot Tensor. The index of the entity.
+        Args:
+            etype (int | str): The topology dimension of the entity, or name
+            'cell' | 'face' | 'edge' | 'node'. Returns sliced node if 'node'.
+            index (int | slice | Tensor): The index of the entity.
 
-        @return: Tensor.
+        Returns:
+            Tensor: A 2-d tensor containing barycenters of the entity.
         """
         if etype in ('node', 0):
             return self.node if index is None else self.node[index]
@@ -350,28 +353,31 @@ class Mesh():
         return F.entity_barycenter(etn, node)
 
     def integrator(self, q: int, etype: Union[int, str]='cell', qtype: str='legendre') -> Quadrature:
-        r"""@brief Get the quadrature points and weights."""
+        """Get the quadrature points and weights."""
         raise NotImplementedError
 
-    def shape_function(self, bc: Tensor, p: int=1, *, index: Tensor,
+    def shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
                        variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
-        """@brief Shape function value on the given bc points, in shape (..., ldof).
+        """Shape function value on the given bc points, in shape (..., ldof).
 
-        @param bc: The bc points, in shape (..., NVC).
-        @param p: The order of the shape function.
-        @param index: The index of the cell.
-        @param variable: The variable name.
-        @param mi: The multi-index matrix.
+        Args:
+            bc (Tensor): The bc points, in shape (..., NVC).
+            p (int, optional): The order of the shape function. Defaults to 1.
+            index (int | slice | Tensor, optional): The index of the cell.
+            variable (str, optional): The variable name. Defaults to 'u'.
+            mi (Tensor, optional): The multi-index matrix. Defaults to None.
 
-        @returns: The shape function value, in shape (..., ldof).
+        Returns:
+            Tensor: The shape function value with shape (..., ldof). The shape will\
+            be (..., 1, ldof) if `variable == 'x'`.
         """
         raise NotImplementedError(f"shape function is not supported by {self.__class__.__name__}")
 
-    def grad_shape_function(self, bc: Tensor, p: int=1, *, index: Tensor,
+    def grad_shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
                             variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
         raise NotImplementedError(f"grad shape function is not supported by {self.__class__.__name__}")
 
-    def hess_shape_function(self, bc: Tensor, p: int=1, *, index: Tensor,
+    def hess_shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
                             variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
         raise NotImplementedError(f"hess shape function is not supported by {self.__class__.__name__}")
 
@@ -384,9 +390,10 @@ class HomoMesh(Mesh):
         entity = self.ds.entity(etype, index)
         return F.homo_entity_barycenter(entity, node)
 
-    def bc_to_point(self, bcs: Union[Tensor, Sequence[Tensor]], etype='cell', index=_S) -> Tensor:
-        r"""@brief Convert barycenter coordinate points to cartesian coordinate points
-            on mesh entities.
+    def bc_to_point(self, bcs: Union[Tensor, Sequence[Tensor]],
+                    etype: Union[int, str]='cell', index: Index=_S) -> Tensor:
+        """Convert barycenter coordinate points to cartesian coordinate points
+        on mesh entities.
         """
         node = self.entity('node')
         entity = self.ds.entity(etype, index)
@@ -400,7 +407,7 @@ class HomoMesh(Mesh):
         raise NotImplementedError
 
     def edge_to_ipoint(self, p: int, index: Index=_S) -> Tensor:
-        r"""@brief Get the relationship between edges and integration points."""
+        """Get the relationship between edges and integration points."""
         NN = self.number_of_nodes()
         NE = self.number_of_edges()
         edges = self.ds.edge[index]

--- a/fealpy/torch/mesh/triangle_mesh.py
+++ b/fealpy/torch/mesh/triangle_mesh.py
@@ -68,6 +68,7 @@ class TriangleMeshDataStructure(HomoMeshDataStructure):
 
 
 class TriangleMesh(HomoMesh):
+    ds: TriangleMeshDataStructure
     def __init__(self, node: Tensor, cell: Tensor) -> None:
         self.node = node
         self.ds = TriangleMeshDataStructure(node.shape[0], cell)


### PR DESCRIPTION
### New
- add `edge_length`, `edge_normal` and `edge_unit_normal` in mesh base.
- add `set_coef` and `set_source` methods in integrators to enable changing coef or source after initialization. This is useful when solving many equations with different coefs or source terms.
- add `get_source_val` and `get_source_int` methods in `ScalarBoundarySourceIntegrator`. These are mainly for testing.

### Update
- update many docstrings.