### PR TITLE
add IntervalMesh and ScalarMassIntegrator in the torch module

### DIFF
--- a/fealpy/torch/fem/__init__.py
+++ b/fealpy/torch/fem/__init__.py
@@ -6,6 +6,7 @@ from .linear_form import LinearForm
 
 ### Cell Operator
 from .scalar_diffusion_integrator import ScalarDiffusionIntegrator
+from .scalar_mass_integrator import ScalarMassIntegrator
 
 ### Cell Source
 from .scalar_source_integrator import ScalarSourceIntegrator

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from ..functionspace.space import FunctionSpace as _FS
 
 Index = Union[int, slice, Tensor]
+_S = slice(None)
 CoefLike = Union[float, int, Tensor, Callable[..., Tensor]]
 _Meth = TypeVar('_Meth', bound=Callable[..., Any])
 

--- a/fealpy/torch/fem/scalar_boundary_source_integrator.py
+++ b/fealpy/torch/fem/scalar_boundary_source_integrator.py
@@ -3,7 +3,7 @@ from typing import Optional, Callable
 
 from torch import Tensor
 
-from ..mesh import HomoMesh
+from ..mesh import HomogeneousMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import linear_integral, integral
@@ -32,7 +32,7 @@ class ScalarBoundarySourceIntegrator(FaceSourceIntegrator):
         q = self.q
         mesh = getattr(space, 'mesh', None)
 
-        if not isinstance(mesh, HomoMesh):
+        if not isinstance(mesh, HomogeneousMesh):
             raise RuntimeError("The ScalarBoundarySourceIntegrator only support spaces on"
                                f"homogeneous meshes, but {type(mesh).__name__} is"
                                "not a subclass of HomoMesh.")

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from torch import Tensor
 
-from ..mesh import HomoMesh
+from ..mesh import HomogeneousMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import bilinear_integral
@@ -33,7 +33,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         index = self.index
         mesh = getattr(space, 'mesh', None)
 
-        if not isinstance(mesh, HomoMesh):
+        if not isinstance(mesh, HomogeneousMesh):
             raise RuntimeError("The ScalarDiffusionIntegrator only support spaces on"
                                f"homogeneous meshes, but {type(mesh).__name__} is"
                                "not a subclass of HomoMesh.")

--- a/fealpy/torch/functionspace/lagrange_fe_space.py
+++ b/fealpy/torch/functionspace/lagrange_fe_space.py
@@ -32,22 +32,22 @@ class LagrangeFESpace(FunctionSpace, Generic[_MT]):
         self.TD = mesh.top_dimension()
         self.GD = mesh.geo_dimension()
 
-    def number_of_local_dofs(self, doftype='cell'):
+    def number_of_local_dofs(self, doftype='cell') -> int:
         return self.dof.number_of_local_dofs(doftype=doftype)
 
-    def number_of_global_dofs(self):
+    def number_of_global_dofs(self) -> int:
         return self.dof.number_of_global_dofs()
 
-    def interpolation_points(self):
+    def interpolation_points(self) -> Tensor:
         return self.dof.interpolation_points()
 
-    def cell_to_dof(self):
+    def cell_to_dof(self) -> Tensor:
         return self.dof.cell_to_dof()
 
-    def face_to_dof(self):
+    def face_to_dof(self) -> Tensor:
         return self.dof.face_to_dof()
 
-    def is_boundary_dof(self, threshold=None):
+    def is_boundary_dof(self, threshold=None) -> Tensor:
         if self.ctype == 'C':
             return self.dof.is_boundary_dof(threshold)
         else:
@@ -101,8 +101,24 @@ class LagrangeFESpace(FunctionSpace, Generic[_MT]):
         return self.mesh.hess_shape_function(bc, self.p, index=index, variable=variable)
 
     def value(self, uh: Tensor, bc: Tensor, index: Index=_S):
-        """
-        @brief
+        """Calculate the value of the finite element function.
+
+        Args:
+            uh (Tensor): Dofs of the function, shaped (..., gdof) for 'sdofs' and
+            'batched', (gdof, ...) for 'vdims'.
+            bc (Tensor): Input points in barycentric coordinates, shaped (NQ, NVC).
+            index (Index, optional): _description_.
+
+        Raises:
+            ValueError: _description_
+
+        Returns:
+            Tensor: Function value. Its shape varies according to the `doforder` of space.
+            - Returns a Tensor of shape (NQ, ..., NC) if `doforder` is 'sdofs'.
+            - Returns a Tensor of shape (NQ, NC, ...) if `doforder` is 'vdims'.
+            - Returns a Tensor of shape (..., NQ, NC) if `doforder` is 'batched'.
+
+            Defaults to 'batched' if the space does not have `doforder` attribute.
         """
         phi = self.basis(bc, index=index)
         cell2dof = self.dof.cell_to_dof(index)

--- a/fealpy/torch/mesh/__init__.py
+++ b/fealpy/torch/mesh/__init__.py
@@ -1,4 +1,6 @@
 
-from .mesh_base import MeshDataStructure, HomoMeshDataStructure
-from .mesh_base import Mesh, HomoMesh
+from .mesh_base import MeshDS
+from .mesh_base import Mesh, HomogeneousMesh, SimplexMesh
+
+from .interval_mesh import IntervalMesh
 from .triangle_mesh import TriangleMesh

--- a/fealpy/torch/mesh/functional.py
+++ b/fealpy/torch/mesh/functional.py
@@ -121,8 +121,8 @@ def homo_entity_barycenter(entity: Tensor, node: Tensor):
     return torch.mean(node[entity, :], dim=1)
 
 
-# Triangle Mesh & Tetrahedron Mesh
-# ================================
+# Interval Mesh & Triangle Mesh & Tetrahedron Mesh
+# ================================================
 
 def simplex_ldof(p: int, iptype: int) -> int:
     r"""Number of local DoFs of a simplex."""
@@ -168,6 +168,23 @@ def simplex_measure(points: Tensor):
 ### Final Mesh
 ##################################################
 
+# Interval Mesh
+# =============
+
+def int_grad_lambda(points: Tensor):
+    """grad_lambda function for the interval mesh.
+
+    Args:
+        points (Tensor[..., 2, GD]): _description_
+
+    Returns:
+        Tensor: grad lambda tensor shaped [..., 2, GD].
+    """
+    v = points[..., 1, :] - points[..., 0, :] # (NC, GD)
+    h2 = torch.sum(v**2, dim=-1, keepdim=True)
+    v = v.div(h2)
+    return torch.stack([-v, v], dim=-2)
+
 # Triangle Mesh
 # =============
 
@@ -177,7 +194,7 @@ def tri_area_3d(points: Tensor, out: Optional[Tensor]=None):
 
 
 def tri_grad_lambda_2d(points: Tensor):
-    r"""
+    """grad_lambda function for the triangle mesh in 2D.
     Args:
         points: Tensor(..., 3, 2).
 

--- a/fealpy/torch/mesh/interval_mesh.py
+++ b/fealpy/torch/mesh/interval_mesh.py
@@ -1,0 +1,143 @@
+
+from typing import Optional, Union, List
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from fealpy.torch.mesh.mesh_base import _S
+from fealpy.torch.mesh.quadrature import Quadrature
+
+from .. import logger
+from . import functional as F
+from .mesh_base import MeshDS, SimplexMesh, entity_str2dim
+
+Index = Union[Tensor, int, slice]
+_dtype = torch.dtype
+_device = torch.device
+
+_S = slice(None)
+
+
+class IntervalMeshDataStructure(MeshDS):
+    def __init__(self, NN: int, cell: Tensor) -> None:
+        super().__init__(NN, 1)
+        self.cell = cell
+
+        self.construct()
+
+    def total_face(self):
+        return self.cell.reshape(-1, 1)
+
+
+class IntervalMesh(SimplexMesh):
+    def __init__(self, node: Tensor, cell: Tensor):
+        if node.ndim == 1:
+            node = node.reshape(-1, 1)
+        self.node = node
+        self.ds = IntervalMeshDataStructure(node.shape[0], cell)
+
+    # entity
+    def entity_measure(self, etype: Union[int, str], index: Optional[Index]=None) -> Tensor:
+        node = self.node
+        if isinstance(etype, str):
+            etype = entity_str2dim(self.ds, etype)
+        if etype == 0:
+            return torch.zeros((1,), dtype=node.dtype, device=node.device)
+        elif etype == 1:
+            edge = self.entity(1, index)
+            return F.edge_length(node[edge])
+        else:
+            raise ValueError(f"Unsupported entity or top-dimension: {etype}")
+
+    # integrator
+    def integrator(self, q: int, etype: Union[int, str]='cell',
+                   qtype: str='legendre') -> Quadrature: # TODO: other qtype
+        from .quadrature import GaussLegendreQuadrature
+
+        if isinstance(etype, str):
+            etype = entity_str2dim(self.ds, etype)
+        kwargs = {'dtype': self.ftype, 'device': self.device}
+        if etype == 1:
+            quad = GaussLegendreQuadrature(**kwargs)
+        else:
+            raise ValueError(f"Unsupported entity or top-dimension: {etype}")
+        quad._latest_order = q
+        return quad
+
+    # ipoints
+    def number_of_local_ipoints(self, p: int, iptype: Union[int, str]='cell'):
+        if isinstance(iptype, str):
+            iptype = entity_str2dim(self.ds, iptype)
+        return F.simplex_ldof(p, iptype)
+
+    def number_of_global_ipoints(self, p: int):
+        return F.simplex_gdof(p, self)
+
+    def interpolation_points(self, p: int, index: Index=_S) -> Tensor:
+        """Fetch all p-order interpolation points on the interval mesh."""
+        node = self.entity('node')
+        if p == 1:
+            return node
+        if p <= 0:
+            raise ValueError("p must be a integer larger than 0.")
+
+        ipoint_list = []
+        kwargs = {'dtype': self.ftype, 'device': self.device}
+
+        GD = self.geo_dimension()
+        ipoint_list.append(node)
+
+        edge = self.entity('edge')
+        w = torch.zeros((p - 1, 2), **kwargs)
+        w[:, 0] = torch.arange(p - 1, 0, -1).div_(p)
+        w[:, 1] = w[:, 0].flip(0)
+        ipoints_from_edge = np.einsum('ij, kj... -> ki...', w,
+                                      node[edge]).reshape(-1, GD)
+        ipoint_list.append(ipoints_from_edge)
+
+        return torch.cat(ipoint_list, dim=0)
+
+    def cell_to_ipoint(self, p: int, index: Index=_S) -> Tensor:
+        return self.edge_to_ipoint(p, index)
+
+    def face_to_ipoint(self, p: int, index: Index=_S) -> Tensor:
+        NN = self.number_of_nodes()
+        return torch.arange(NN, dtype=self.ds.itype, device=self.device)
+
+    # shape function
+    def grad_lambda(self, index: Index=_S):
+        return F.int_grad_lambda(self.node[self.ds.cell[index]])
+
+    # constructor
+    @classmethod
+    def from_mesh_boundary(cls, mesh, /):
+        """Construct a interval mesh from the boundary of a mesh with topology
+        dimension 2.
+
+        Args:
+            mesh (Mesh): The mesh whose boundary is to construct the interval mesh on.
+
+        Raises:
+            ValueError: If the top-dimension of the mesh is not 2.
+
+        Returns:
+            IntervalMesh: _description_
+        """
+        if mesh.top_dimension() != 2:
+            raise ValueError("The top-dimension of the mesh must be 2.")
+
+        itype = mesh.ds.itype
+        device = mesh.device
+        is_bd_node = mesh.ds.boundary_node_flag()
+        is_bd_face = mesh.ds.boundary_face_flag()
+        node = mesh.entity('node', index=is_bd_node)
+        face = mesh.entity('face', index=is_bd_face)
+        NN = mesh.number_of_nodes()
+        NN_bd = node.shape[0]
+
+        I = torch.zeros((NN, ), dtype=itype, device=device)
+        I[is_bd_node] = torch.arange(NN_bd, dtype=itype, device=device)
+        face2bdnode = I[face]
+
+        return cls(node=node, cell=face2bdnode)

--- a/fealpy/torch/mesh/triangle_mesh.py
+++ b/fealpy/torch/mesh/triangle_mesh.py
@@ -10,8 +10,7 @@ from fealpy.torch.mesh.quadrature import Quadrature
 
 from .. import logger
 from . import functional as F
-from . import mesh_kernel as K
-from .mesh_base import HomoMeshDataStructure, HomoMesh, entity_str2dim
+from .mesh_base import MeshDS, SimplexMesh, entity_str2dim
 
 Index = Union[Tensor, int, slice]
 _dtype = torch.dtype
@@ -20,11 +19,12 @@ _device = torch.device
 _S = slice(None)
 
 
-class TriangleMeshDataStructure(HomoMeshDataStructure):
+class TriangleMeshDataStructure(MeshDS):
     def __init__(self, NN: int, cell: Tensor):
-        super().__init__(NN, 2, cell)
+        super().__init__(NN, 2)
         # constant tensors
         kwargs = {'dtype': cell.dtype, 'device': cell.device}
+        self.cell = cell
         self.localEdge = torch.tensor([(1, 2), (2, 0), (0, 1)], **kwargs)
         self.localFace = torch.tensor([(1, 2), (2, 0), (0, 1)], **kwargs)
         self.ccw = torch.tensor([0, 1, 2], **kwargs)
@@ -39,35 +39,8 @@ class TriangleMeshDataStructure(HomoMeshDataStructure):
     def total_face(self):
         return self.cell[..., self.localFace].reshape(-1, 2)
 
-    def construct(self) -> None:
-        NC = self.cell.shape[0]
-        NFC = self.cell.shape[1]
 
-        totalFace = self.total_face()
-        _, i0_np, j_np = np.unique(
-            torch.sort(totalFace, dim=1)[0].cpu().numpy(),
-            return_index=True,
-            return_inverse=True,
-            axis=0
-        )
-        self.face = totalFace[i0_np, :] # this also adds the edge in 2-d meshes
-        NF = i0_np.shape[0]
-
-        i1_np = np.zeros(NF, dtype=i0_np.dtype)
-        i1_np[j_np] = np.arange(NFC*NC, dtype=i0_np.dtype)
-
-        self.cell2edge = torch.from_numpy(j_np).to(self.device).reshape(NC, NFC)
-        self.cell2face = self.cell2edge
-
-        face2cell_np = np.stack([i0_np//NFC, i1_np//NFC, i0_np%NFC, i1_np%NFC], axis=-1)
-        self.face2cell = torch.from_numpy(face2cell_np).to(self.device)
-        self.edge2cell = self.face2cell
-
-        logger.info(f"Mesh toplogy relation constructed, with {NF} edge (or face), "
-                    f"on device {self.device}")
-
-
-class TriangleMesh(HomoMesh):
+class TriangleMesh(SimplexMesh):
     ds: TriangleMeshDataStructure
     def __init__(self, node: Tensor, cell: Tensor) -> None:
         self.node = node
@@ -86,6 +59,7 @@ class TriangleMesh(HomoMesh):
                         "cell_area and grad_lambda are not available. "
                         "Any operation involving them will fail.")
 
+    # entity
     def entity_measure(self, etype: Union[int, str], index: Optional[Index]=None) -> Tensor:
         node = self.node
         if isinstance(etype, str):
@@ -101,6 +75,7 @@ class TriangleMesh(HomoMesh):
         else:
             raise ValueError(f"Unsupported entity or top-dimension: {etype}")
 
+    # integrator
     def integrator(self, q: int, etype: Union[int, str]='cell',
                    qtype: str='legendre') -> Quadrature: # TODO: other qtype
         from .quadrature import TriangleQuadrature
@@ -118,6 +93,7 @@ class TriangleMesh(HomoMesh):
         quad._latest_order = q
         return quad
 
+    # ipoints
     def number_of_local_ipoints(self, p: int, iptype: Union[int, str]='cell'):
         if isinstance(iptype, str):
             iptype = entity_str2dim(self.ds, iptype)
@@ -126,17 +102,14 @@ class TriangleMesh(HomoMesh):
     def number_of_global_ipoints(self, p: int):
         return F.simplex_gdof(p, self)
 
-    def interpolation_points(self, p: int, index=np.s_[:]):
-        """
-        @brief Fetch all p-order interpolation points on a triangle mesh.
-        """
+    def interpolation_points(self, p: int, index: Index=_S) -> Tensor:
+        """Fetch all p-order interpolation points on the triangle mesh."""
         node = self.entity('node')
         if p == 1:
             return node
         if p <= 0:
             raise ValueError("p must be a integer larger than 0.")
 
-        cell = self.entity('cell')
         ipoint_list = []
         kwargs = {'dtype': self.ftype, 'device': self.device}
 
@@ -153,6 +126,7 @@ class TriangleMesh(HomoMesh):
 
         if p >= 3:
             TD = self.top_dimension()
+            cell = self.entity('cell')
             multiIndex = self.multi_index_matrix(p, TD)
             isEdgeIPoints = (multiIndex == 0)
             isInCellIPoints = ~(isEdgeIPoints[:, 0] | isEdgeIPoints[:, 1] |
@@ -212,38 +186,11 @@ class TriangleMesh(HomoMesh):
     def face_to_ipoint(self, p: int, index: Index=_S) -> Tensor:
         return self.edge_to_ipoint(p, index)
 
+    # shape function
     def grad_lambda(self, index: Index=_S):
         return self._grad_lambda(self.node[self.ds.cell[index]])
 
-    def shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
-                       variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
-        TD = bc.shape[-1] - 1
-        mi = mi or F.multi_index_matrix(p, TD, dtype=self.ds.itype, device=self.device)
-        phi = K.simplex_shape_function(bc, p, mi)
-        if variable == 'u':
-            return phi
-        elif variable == 'x':
-            return phi.unsqueeze_(1)
-        else:
-            raise ValueError("Variable type is expected to be 'u' or 'x', "
-                             f"but got '{variable}'.")
-
-    def grad_shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
-                            variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
-        TD = bc.shape[-1] - 1
-        mi = mi or F.multi_index_matrix(p, TD, dtype=self.ds.itype, device=self.device)
-        R = K.simplex_grad_shape_function(bc, p, mi) # (NQ, ldof, bc)
-        if variable == 'u':
-            return R
-        elif variable == 'x':
-            Dlambda = self.grad_lambda(index=index)
-            gphi = torch.einsum('...bm, kjb -> k...jm', Dlambda, R) # (NQ, NC, ldof, dim)
-            # NOTE: the subscript 'k': NQ, 'm': dim, 'j': ldof, 'b': bc, '...': cell
-            return gphi
-        else:
-            raise ValueError("Variable type is expected to be 'u' or 'x', "
-                             f"but got '{variable}'.")
-
+    # constructor
     @classmethod
     def from_box(cls, box: List[int]=[0, 1, 0, 1], nx=10, ny=10, threshold=None, *,
                  itype: Optional[_dtype]=torch.int,

--- a/fealpy/torch/utils.py
+++ b/fealpy/torch/utils.py
@@ -4,7 +4,7 @@ from typing import Optional, Union, Callable
 
 from torch import Tensor
 
-from .mesh import HomoMesh, Mesh
+from .mesh import HomogeneousMesh, Mesh
 
 Number = Union[builtins.int, builtins.float]
 CoefLike = Union[Number, Tensor, Callable[..., Tensor]]
@@ -14,7 +14,7 @@ Index = Union[slice, Tensor, int]
 def process_coef_func(
     coef: Optional[CoefLike],
     bcs: Optional[Tensor]=None,
-    mesh: Optional[HomoMesh]=None,
+    mesh: Optional[HomogeneousMesh]=None,
     etype: Optional[Union[int, str]]=None,
     index: Optional[Tensor]=None
 ):
@@ -27,7 +27,7 @@ def process_coef_func(
         if etype is None:
             raise RuntimeError('The etype should be provided for coef functions.')
         if getattr(coef, 'coordtype', 'cartesian') == 'cartesian':
-            if (mesh is None) or (not isinstance(mesh, HomoMesh)):
+            if (mesh is None) or (not isinstance(mesh, HomogeneousMesh)):
                 raise RuntimeError('The mesh should be provided for cartesian coef functions.'
                                    'Note that only homogeneous meshes are supported here.')
 


### PR DESCRIPTION
### New
- add `IntervalMesh`.
- add `ScalarMassIntegrator`.
Note: These two are implemented to solve the eigenvalue problem of the LB operator.

### Update
- change the names of some mesh base classes: `Mesh`, `HomogeneousMesh`, `MeshDS`..., keeping them consistent with the numpy version.
- change the class inheritance structure of `MeshDS`.
- the shape function of interval mesh, triangle mesh and tetrahedron mesh (in the future) is now placed in a subclass of `HomogeneousMesh` named `SimplexMesh`.
- the `construct` function is now placed in `MeshDS`.