### PR TITLE
Add assemblymethod for integrators; add Function

### DIFF
--- a/app/eit/box_tri_generate.py
+++ b/app/eit/box_tri_generate.py
@@ -57,8 +57,9 @@ output_folder = config['output_folder']
 kwargs = {"dtype": DTYPE, "device": DEVICE}
 os.path.join(output_folder, "")
 
-if not os.path.exists(output_folder):
-    os.makedirs(output_folder)
+os.makedirs(output_folder, exist_ok=True)
+os.makedirs(os.path.join(output_folder, f'gd'), exist_ok=True)
+os.makedirs(os.path.join(output_folder, f'inclusion'), exist_ok=True)
 
 
 def neumann(points: Tensor):
@@ -92,9 +93,12 @@ def main(sigma_iterable: Sequence[int], seed=0, index=0):
         label = generator.set_levelset(SIGMA, ls_fn)
         gd = generator.run()
 
+        np.save(
+            os.path.join(output_folder, f'gd/{sigma_idx}.npy'),
+            gd.numpy()
+        )
         np.savez(
-            os.path.join(output_folder, f'gd_{sigma_idx}.npz'),
-            gd=gd.numpy(),
+            os.path.join(output_folder, f'inclusion/{sigma_idx}.npz'),
             label=label.cpu().numpy(),
             ctrs=ctrs.cpu().numpy(),
             rads=rads.cpu().numpy()

--- a/fealpy/torch/fem/integrator.py
+++ b/fealpy/torch/fem/integrator.py
@@ -1,6 +1,5 @@
 
-from abc import ABCMeta, abstractmethod
-from typing import Union, Callable, Optional, Any, TypeVar
+from typing import Union, Callable, Optional, Any, TypeVar, Dict
 
 from torch import Tensor
 
@@ -12,7 +11,65 @@ CoefLike = Union[float, int, Tensor, Callable[..., Tensor]]
 _Meth = TypeVar('_Meth', bound=Callable[..., Any])
 
 
+class IntegratorMeta(type):
+    def __init__(self, name: str, bases: tuple[type, ...], dict: dict[str, Any], /, **kwds: Any):
+        for meth_name, meth in dict.items():
+            if callable(meth):
+                if hasattr(meth, '__call_name__'):
+                    call_name = getattr(meth, '__call_name__')
+                    if call_name is None:
+                        call_name = meth_name
+                    if not hasattr(self, '_assembly_map'):
+                        self._assembly_map = {}
+                    self._assembly_map[call_name] = meth_name
+
+        return type.__init__(self, name, bases, dict, **kwds)
+
+
+def assemblymethod(call_name: Optional[str]=None):
+    """A decorator registering the method as an assembly method.
+
+    Requires that the metaclass is IntegratorMeta or derived from it.
+
+    Args:
+        call_name (str, optional): The name for the users to choose the assembly method with.
+        Use the name of the method if None. Defaults to None.
+
+    Example:
+    ```
+        class MyIntegrator(Integrator):
+            def assembly(self, space: _FS) -> Tensor:
+                # 'assembly' is the default assembly method,
+                # naturally registered to name 'assembly'.
+                return integral
+
+            @assemblymethod('my')
+            def my_assembly(self, space: _FS) -> Tensor:
+                # code for getting local integral tensor
+                return integral
+    ```
+    Then in the initialization of an integrator instance, use
+    ```
+        integrator = MyIntegrator(method='my')
+    ```
+    to specify the 'my_assembly' as the assembly method called in the __call__.
+    """
+    def decorator(meth: _Meth) -> _Meth:
+        meth.__call_name__ = call_name
+        return meth
+    return decorator
+
+
 def enable_cache(meth: _Meth) -> _Meth:
+    """A decorator indicating that the method should be cached by its `space` arg.
+
+    This is useful for assembly methods supporting coefficient and source to
+    fetch the data like the basis of space and the measurement of mesh entities.
+    Redundant computation can be avoided after coef or source are changed.
+
+    Note that as the result of the integral is automatically cached, assembly
+    methods producing determinant values for a space is unnecessary to use cache.
+    """
     def wrapper(self, space: _FS) -> Tensor:
         if getattr(self, '_cache', None) is None:
             self._cache = {}
@@ -24,13 +81,15 @@ def enable_cache(meth: _Meth) -> _Meth:
     return wrapper
 
 
-class Integrator(metaclass=ABCMeta):
-    r"""@brief The base class for integrators on function spaces."""
-    _value: Optional[Tensor]
-    _assembly: str
+class Integrator(metaclass=IntegratorMeta):
+    """The base class for integrators on function spaces."""
+    _value: Optional[Tensor] = None
+    _assembly_map: Dict[str, str] = {}
 
     def __init__(self, method='assembly') -> None:
-        self._assembly = method
+        if method not in self._assembly_map:
+            raise ValueError(f"No assembly method is registered as '{method}'.")
+        self._assembly = self._assembly_map[method]
 
     def __call__(self, space: _FS) -> Tensor:
         if hasattr(self, '_value') and self._value is not None:
@@ -43,10 +102,13 @@ class Integrator(metaclass=ABCMeta):
             self._value = getattr(self, self._assembly)(space)
             return self._value
 
-    @abstractmethod
     def to_global_dof(self, space: _FS) -> Tensor:
         """Return the relationship between the integral entities
         and the global dofs."""
+        raise NotImplementedError
+
+    @assemblymethod('assembly')
+    def assembly(self, space: _FS) -> Tensor:
         raise NotImplementedError
 
     def clear(self, result_only=True) -> None:
@@ -67,9 +129,6 @@ class Integrator(metaclass=ABCMeta):
 class OperatorIntegrator(Integrator):
     coef: Optional[CoefLike]
 
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
-
     def set_coef(self, coef: Optional[CoefLike]=None, /) -> None:
         """Set a new coefficient of the equation to the integrator.
         This will clear the cached result.
@@ -83,9 +142,6 @@ class OperatorIntegrator(Integrator):
 
 class SourceIntegrator(Integrator):
     source: Optional[CoefLike]
-
-    def assembly(self, space: _FS) -> Tensor:
-        raise NotImplementedError
 
     def set_source(self, source: Optional[CoefLike]=None, /) -> None:
         """Set a new source term of the equation to the integrator.

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -8,7 +8,12 @@ from ..mesh import HomogeneousMesh
 from ..functionspace.space import FunctionSpace as _FS
 from ..utils import process_coef_func
 from ..functional import bilinear_integral
-from .integrator import CellOperatorIntegrator, _S, Index, CoefLike, enable_cache
+from .integrator import (
+    CellOperatorIntegrator,
+    enable_cache,
+    assemblymethod,
+    _S, Index, CoefLike
+)
 
 
 class ScalarDiffusionIntegrator(CellOperatorIntegrator):
@@ -29,7 +34,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         return space.cell_to_dof()[self.index]
 
     @enable_cache
-    def fetch(self, space: _FS) -> Tensor:
+    def fetch(self, space: _FS):
         q = self.q
         index = self.index
         mesh = getattr(space, 'mesh', None)
@@ -53,6 +58,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
 
         return bilinear_integral(gphi, gphi, ws, cm, coef, batched=self.batched)
 
+    @assemblymethod('fast')
     def fast_assembly(self, space: _FS) -> Tensor:
         """
         限制：常系数、单纯形网格

--- a/fealpy/torch/functionspace/__init__.py
+++ b/fealpy/torch/functionspace/__init__.py
@@ -1,4 +1,6 @@
 
+from .space import FunctionSpace, Function
+
 from .dofs import LinearMeshCFEDof
 
 from .lagrange_fe_space import LagrangeFESpace

--- a/fealpy/torch/functionspace/lagrange_fe_space.py
+++ b/fealpy/torch/functionspace/lagrange_fe_space.py
@@ -149,5 +149,5 @@ class LagrangeFESpace(FunctionSpace, Generic[_MT]):
             raise ValueError(f"Unsupported doforder: {self.doforder}. Supported types are: 'sdofs' and 'vdims'.")
         return val
 
-    def grad(self, uh: Tensor, bc: Tensor, index: Index=_S):
+    def grad_value(self, uh: Tensor, bc: Tensor, index: Index=_S):
         pass


### PR DESCRIPTION
### Update
- 为积分子添加 `@assemblymethod` 装饰器。任何积分子的方法可以通过此装饰器被标记为组装方法，并设置一个名字，以供用户在初始化积分子时通过 `method='name'` 参数来选用。

### New
- 在 functionspace 中初步添加继承自 Tensor 的 Function 类，用作空间中的函数。