### PR TITLE
refactor(eit): switch to torch.random for consistent randomness

### DIFF
--- a/app/eit/box_tri_generate.py
+++ b/app/eit/box_tri_generate.py
@@ -73,6 +73,7 @@ def neumann(points: Tensor):
 
 def main(sigma_iterable: Sequence[int], seed=0, index=0):
     torch.manual_seed(seed)
+    np.random.seed(seed)
     mesh = TriangleMesh.from_box((-1, 1, -1, 1), EXT, EXT, ftype=DTYPE, device=DEVICE)
     generator = EITDataGenerator(mesh=mesh, p=P, q=Q)
     gn = generator.set_boundary(neumann, batch_size=len(FREQ))
@@ -85,9 +86,16 @@ def main(sigma_iterable: Sequence[int], seed=0, index=0):
                           dynamic_ncols=True,
                           unit='sample',
                           position=index):
-        ctrs = rand(NUM_CIR, 2, **kwargs) * 1.6 - 0.8 # (NCir, GD)
-        b, _ = torch.min(0.9-torch.abs(ctrs), axis=-1) # (NCir, )
-        rads = rand(NUM_CIR, **kwargs) * (b-0.1) + 0.1 # (NCir, )
+        # ctrs = rand(NUM_CIR, 2, **kwargs) * 1.6 - 0.8 # (NCir, GD)
+        # b, _ = torch.min(0.9-torch.abs(ctrs), axis=-1) # (NCir, )
+        # rads = rand(NUM_CIR, **kwargs) * (b-0.1) + 0.1 # (NCir, )
+
+        ctrs = np.random.rand(NUM_CIR, 2) * 1.6 - 0.8 # (NCir, GD)
+        b = np.min(0.9-np.abs(ctrs), axis=-1) # (NCir, )
+        rads = np.random.rand(NUM_CIR) * (b-0.1) + 0.1 # (NCir, )
+        ctrs = torch.from_numpy(ctrs).to(**kwargs)
+        rads = torch.from_numpy(rads).to(**kwargs)
+
         ls_fn = lambda p: levelset(p, ctrs, rads)
 
         label = generator.set_levelset(SIGMA, ls_fn)

--- a/fealpy/torch/mesh/functional.py
+++ b/fealpy/torch/mesh/functional.py
@@ -110,7 +110,7 @@ def homo_entity_barycenter(entity: Tensor, node: Tensor) -> Tensor:
 # =================================
 
 def simplex_ldof(p: int, iptype: int) -> int:
-    r"""Number of local DoFs of a simplex."""
+    r"""Number of local DoFs of a simplex shape."""
     if iptype == 0:
         return 1
     return comb(p + iptype, iptype)
@@ -196,6 +196,21 @@ def simplex_hess_shape_function(bcs: Tensor, p: int, mi: Tensor) -> Tensor:
 
 # Quadrangle & Hexahedron
 # =======================
+
+def tensor_ldof(p: int, iptype: int) -> int:
+    r"""Number of local DoFs of a tensor shape."""
+    return (p + 1) ** iptype
+
+
+def tensor_gdof(p: int, mesh) -> int:
+    r"""Number of global DoFs of a mesh with tensor cells."""
+    coef = 1
+    count = mesh.node.size(0)
+
+    for i in range(1, mesh.TD + 1):
+        coef = coef * (p-i)
+        count += coef * mesh.entity(i).size(0)
+    return count
 
 
 ##################################################


### PR DESCRIPTION
### Update
- Use torch.random for generating random numbers in EIT module to ensure consistency across different platforms and avoid potential issues with numpy random seed setting.
- Add `TensorMesh` and `StructuredMesh` as subclasses of `HomogeneousMesh`.
- Move the `edge_to_ipoint()` from `HomogeneousMesh` to `Mesh`.