### PR TITLE
Torch 模块轴顺序更改

### DIFF
--- a/fealpy/torch/fem/scalar_boundary_source_integrator.py
+++ b/fealpy/torch/fem/scalar_boundary_source_integrator.py
@@ -39,7 +39,7 @@ class ScalarBoundarySourceIntegrator(FaceSourceIntegrator):
 
         index = mesh.boundary_face_index()
         fm = mesh.entity_measure('face', index=index)
-        qf = mesh.integrator(q, 'face')
+        qf = mesh.quadrature_formula(q, 'face')
         bcs, ws = qf.get_quadrature_points_and_weights()
         phi = space.basis(bcs, index=index, variable='x')
 

--- a/fealpy/torch/fem/scalar_diffusion_integrator.py
+++ b/fealpy/torch/fem/scalar_diffusion_integrator.py
@@ -45,7 +45,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
                                "not a subclass of HomoMesh.")
 
         cm = mesh.entity_measure('cell', index=index)
-        qf = mesh.integrator(q, 'cell')
+        qf = mesh.quadrature_formula(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         gphi = space.grad_basis(bcs, index=index, variable='x')
         return bcs, ws, gphi, cm, index
@@ -69,7 +69,7 @@ class ScalarDiffusionIntegrator(CellOperatorIntegrator):
         mesh = getattr(space, 'mesh', None)
 
         cm = mesh.entity_measure('cell', index=index)
-        qf = mesh.integrator(q, 'cell')
+        qf = mesh.quadrature_formula(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         gphi = space.grad_basis(bcs, index=index, variable='u')
 

--- a/fealpy/torch/fem/scalar_mass_integrator.py
+++ b/fealpy/torch/fem/scalar_mass_integrator.py
@@ -36,7 +36,7 @@ class ScalarMassIntegrator(CellOperatorIntegrator):
                                "not a subclass of HomoMesh.")
 
         cm = mesh.entity_measure('cell', index=index)
-        qf = mesh.integrator(q, 'cell')
+        qf = mesh.quadrature_formula(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         phi = space.basis(bcs, index=index, variable='x')
         return bcs, ws, phi, cm, index

--- a/fealpy/torch/fem/scalar_source_integrator.py
+++ b/fealpy/torch/fem/scalar_source_integrator.py
@@ -37,7 +37,7 @@ class ScalarSourceIntegrator(CellSourceIntegrator):
                                "not a subclass of HomoMesh.")
 
         cm = mesh.entity_measure('cell', index=index)
-        qf = mesh.integrator(q, 'cell')
+        qf = mesh.quadrature_formula(q, 'cell')
         bcs, ws = qf.get_quadrature_points_and_weights()
         phi = space.basis(bcs, index=index, variable='x')
 

--- a/fealpy/torch/functional.py
+++ b/fealpy/torch/functional.py
@@ -16,7 +16,7 @@ def integral(value: Tensor, weights: Tensor, measure: Tensor, *,
     """Numerical integration.
 
     Args:
-        value (Tensor[..., Q, C]): The values on the quadrature points to be integrated.
+        value (Tensor[..., C, Q]): The values on the quadrature points to be integrated.
         weights (Tensor[Q,]): The weights of the quadrature points.
         measure (Tensor[C,]): The measure of the quadrature points.
         entity_type (bool): Whether to return integration in each entity. Defaults to False.
@@ -26,39 +26,39 @@ def integral(value: Tensor, weights: Tensor, measure: Tensor, *,
         if entity_type is True, otherwise [...].
     """
     subs = '...c' if entity_type else '...'
-    return einsum(f'q, c, ...qc -> {subs}', weights, measure, value)
+    return einsum(f'c, q, ...cq -> {subs}', measure, weights, value)
 
 
 def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
                     coef: Union[Number, Tensor, None]=None,
                     batched: bool=False) -> Tensor:
-    r"""Numerical integration.
+    """Numerical integration.
 
     Args:
-        input (Tensor[Q, C, I]): The values on the quadrature points to be integrated.
-        weights (Tensor[Q,]): The weights of the quadrature points.
-        measure (Tensor[C,]): The measure of the quadrature points.
+        input (Tensor[C, Q, I]): The values on the quadrature points to be integrated.\n
+        weights (Tensor[Q,]): The weights of the quadrature points.\n
+        measure (Tensor[C,]): The measure of the quadrature points.\n
         coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
-        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
-        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+            Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (C, Q).
+            If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
         batched (bool, optional): Whether the coef are batched. Defaults to False.
 
     Returns:
         Tensor[C, I]: The result of the integration.
-        If `batched == True`, the shape of the result is (B, C, I).
+            If `batched == True`, the shape of the result is (B, C, I).
     """
     if coef is None:
-        return einsum('q, c, qci -> ci', weights, measure, input)
+        return einsum('c, q, cqi -> ci', measure, weights, input)
 
     NQ = weights.shape[0]
     NC = measure.shape[0]
 
     if is_scalar(coef):
-        return einsum('q, c, qci -> ci', weights, measure, input) * coef
+        return einsum('c, q, cqi -> ci', measure, weights, input) * coef
     elif is_tensor(coef):
         out_subs = 'bci' if batched else 'ci'
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
-        return einsum(f'q, c, qci, {subs} -> {out_subs}', weights, measure, input, coef)
+        return einsum(f'c, q, cqi, {subs} -> {out_subs}', measure, weights, input, coef)
     else:
         raise TypeError(f"coef should be int, float or Tensor, but got {type(coef)}.")
 
@@ -66,33 +66,33 @@ def linear_integral(input: Tensor, weights: Tensor, measure: Tensor,
 def bilinear_integral(input1: Tensor, input2: Tensor, weights: Tensor, measure: Tensor,
                       coef: Union[Number, Tensor, None]=None,
                       batched: bool=False) -> Tensor:
-    r"""Numerical integration.
+    """Numerical integration.
 
     Args:
-        input1 (Tensor[Q, C, I, ...]): The values on the quadrature points to be integrated.
-        input2 (Tensor[Q, C, J, ...]): The values on the quadrature points to be integrated.
-        weights (Tensor[Q,]): The weights of the quadrature points.
-        measure (Tensor[C,]): The measure of the quadrature points.
+        input1 (Tensor[C, Q, I, ...]): The values on the quadrature points to be integrated.\n
+        input2 (Tensor[C, Q, J, ...]): The values on the quadrature points to be integrated.\n
+        weights (Tensor[Q,]): The weights of the quadrature points.\n
+        measure (Tensor[C,]): The measure of the quadrature points.\n
         coef (Number, Tensor, optional): The coefficient of the integration. Defaults to None.
-        Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (Q, C).
-        If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
+            Must be int, float, Tensor, or callable returning Tensor with shape (Q,), (C,) or (C, Q).
+            If `batched == True`, the shape of the coef should be (B, C, Q) or (B, C).
         batched (bool, optional): Whether the coef are batched. Defaults to False.
 
     Returns:
         Tensor[C, I, J]: The result of the integration.
-        If `batched == True`, the shape of the output is (B, C, I, J).
+            If `batched == True`, the shape of the output is (B, C, I, J).
     """
     if coef is None:
-        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2)
+        return einsum('c, q, cqi..., cqj... -> cij', measure, weights, input1, input2)
 
     NQ = weights.shape[0]
     NC = measure.shape[0]
 
     if is_scalar(coef):
-        return einsum('q, c, qci..., qcj... -> cij', weights, measure, input1, input2) * coef
+        return einsum('c, q, cqi..., cqj... -> cij', measure, weights, input1, input2) * coef
     elif is_tensor(coef):
         out_subs = 'bcij' if batched else 'cij'
         subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
-        return einsum(f'q, c, qci..., qcj..., {subs} -> {out_subs}', weights, measure, input1, input2, coef)
+        return einsum(f'c, q, cqi..., cqj..., {subs} -> {out_subs}', measure, weights, input1, input2, coef)
     else:
         raise TypeError(f"coef should be int, float or Tensor, but got {type(coef)}.")

--- a/fealpy/torch/mesh/functional.py
+++ b/fealpy/torch/mesh/functional.py
@@ -91,14 +91,24 @@ def bc_tensor(bcs: Sequence[Tensor]) -> Tensor:
 
 def bc_to_points(bcs: Union[Tensor, Sequence[Tensor]], node: Tensor,
                  entity: Tensor, order: Optional[Tensor]) -> Tensor:
-    r"""Barycentric coordinates to cartesian coordinates in homogeneous meshes."""
+    """Barycentric coordinates to cartesian coordinates in homogeneous meshes.
+
+    Parameters:
+        bcs (Tensor | Sequence[Tensor]): Barycentric coordinates, shaped (..., bc).\n
+        node (Tensor): Node coordinates.\n
+        entity (Tensor): Entity indices.\n
+        order (Tensor | None): Order of entities. Defaults to None.
+
+    Returns:
+        Tensor[NC, ..., GD]: Cartesian coordinates.
+    """
     if order is not None:
         entity = entity[:, order]
     points = node[entity, :]
 
     if not isinstance(bcs, Tensor):
         bcs = bc_tensor(bcs)
-    return torch.einsum('ijk, ...j -> ...ik', points, bcs)
+    return torch.einsum('ijk, ...j -> i...k', points, bcs)
 
 
 def homo_entity_barycenter(entity: Tensor, node: Tensor) -> Tensor:

--- a/fealpy/torch/mesh/interval_mesh.py
+++ b/fealpy/torch/mesh/interval_mesh.py
@@ -46,9 +46,9 @@ class IntervalMesh(SimplexMesh):
         else:
             raise ValueError(f"Unsupported entity or top-dimension: {etype}")
 
-    # integrator
-    def integrator(self, q: int, etype: Union[int, str]='cell',
-                   qtype: str='legendre') -> Quadrature: # TODO: other qtype
+    # quadrature
+    def quadrature_formula(self, q: int, etype: Union[int, str]='cell',
+                           qtype: str='legendre') -> Quadrature: # TODO: other qtype
         from .quadrature import GaussLegendreQuadrature
 
         if isinstance(etype, str):

--- a/fealpy/torch/mesh/interval_mesh.py
+++ b/fealpy/torch/mesh/interval_mesh.py
@@ -42,7 +42,7 @@ class IntervalMesh(SimplexMesh):
             return torch.zeros((1,), dtype=node.dtype, device=node.device)
         elif etype == 1:
             edge = self.entity(1, index)
-            return F.edge_length(node[edge])
+            return F.edge_length(edge, node)
         else:
             raise ValueError(f"Unsupported entity or top-dimension: {etype}")
 
@@ -95,7 +95,7 @@ class IntervalMesh(SimplexMesh):
 
     # shape function
     def grad_lambda(self, index: Index=_S):
-        return F.int_grad_lambda(self.node[self.cell[index]])
+        return F.int_grad_lambda(self.cell[index], self.node)
 
     # constructor
     @classmethod

--- a/fealpy/torch/mesh/mesh_base.py
+++ b/fealpy/torch/mesh/mesh_base.py
@@ -402,7 +402,7 @@ class Mesh(MeshDS):
             Tensor[NE,]: Length of edges, shaped [NE,].
         """
         edge = self.entity(1, index=index)
-        return F.edge_length(self.node[edge], out=out)
+        return F.edge_length(edge, self.node, out=out)
 
     def edge_normal(self, index: Index=_S, unit: bool=False, out=None) -> Tensor:
         """Calculate the normal of the edges.
@@ -416,7 +416,7 @@ class Mesh(MeshDS):
             Tensor[NE, GD]: _description_
         """
         edge = self.entity(1, index=index)
-        return F.edge_normal(self.node[edge], unit=unit, out=out)
+        return F.edge_normal(edge, self.node, unit=unit, out=out)
 
     def edge_unit_normal(self, index: Index=_S, out=None) -> Tensor:
         """Calculate the unit normal of the edges.
@@ -476,7 +476,7 @@ class Mesh(MeshDS):
 
     def grad_shape_function(self, bc: Tensor, p: int=1, *, index: Index=_S,
                             variable: str='u', mi: Optional[Tensor]=None) -> Tensor:
-        """Shape function value on the given bc points, in shape (..., ldof, bc).
+        """Gradient of shape function on the given bc points, in shape (..., ldof, bc).
 
         Parameters:
             bc (Tensor): The bc points, in shape (NQ, bc).\n
@@ -619,3 +619,15 @@ class StructuredMesh(HomogeneousMesh):
             self._entity_storage[etype_dim] = entity
 
             return entity
+
+    def _node(self):
+        raise NotImplementedError
+
+    def _edge(self):
+        raise NotImplementedError
+
+    def _face(self):
+        raise NotImplementedError
+
+    def _cell(self):
+        raise NotImplementedError

--- a/fealpy/torch/mesh/triangle_mesh.py
+++ b/fealpy/torch/mesh/triangle_mesh.py
@@ -58,10 +58,10 @@ class TriangleMesh(SimplexMesh):
             return torch.tensor([0,], dtype=self.ftype, device=self.device)
         elif etype == 1:
             edge = self.entity(1, index)
-            return F.edge_length(node[edge])
+            return F.edge_length(edge, node)
         elif etype == 2:
             cell = self.entity(2, index)
-            return self._cell_area(node[cell])
+            return self._cell_area(cell, node)
         else:
             raise ValueError(f"Unsupported entity or top-dimension: {etype}")
 
@@ -170,7 +170,7 @@ class TriangleMesh(SimplexMesh):
 
     # shape function
     def grad_lambda(self, index: Index=_S):
-        return self._grad_lambda(self.node[self.cell[index]])
+        return self._grad_lambda(self.cell[index], self.node)
 
     # constructor
     @classmethod

--- a/fealpy/torch/mesh/triangle_mesh.py
+++ b/fealpy/torch/mesh/triangle_mesh.py
@@ -65,9 +65,9 @@ class TriangleMesh(SimplexMesh):
         else:
             raise ValueError(f"Unsupported entity or top-dimension: {etype}")
 
-    # integrator
-    def integrator(self, q: int, etype: Union[int, str]='cell',
-                   qtype: str='legendre') -> Quadrature: # TODO: other qtype
+    # quadrature
+    def quadrature_formula(self, q: int, etype: Union[int, str]='cell',
+                           qtype: str='legendre') -> Quadrature: # TODO: other qtype
         from .quadrature import TriangleQuadrature
         from .quadrature import GaussLegendreQuadrature
 

--- a/fealpy/torch/utils.py
+++ b/fealpy/torch/utils.py
@@ -56,26 +56,26 @@ def is_tensor(input: Union[int, float, Tensor]) -> bool:
 def get_coef_subscripts(shape: Tensor, nq: int, nc: int, batched: bool):
     if batched:
         coef_shape = shape[1:]
-        if coef_shape == (nq, nc):
-            subs = "bqc"
+        if coef_shape == (nc, nq):
+            subs = "bcq"
         elif coef_shape == (nq, ):
             subs = "bq"
         elif coef_shape == (nc, ):
             subs = "bc"
         else:
-            raise RuntimeError(f"The shape of the coef should be (Batch, {nq}, {nc}), "
+            raise RuntimeError(f"The shape of the coef should be (Batch, {nc}, {nq}), "
                                f"(Batch, {nq}) or (Batch, {nc}), but got {tuple(shape)}.")
 
     else:
         coef_shape = shape
-        if coef_shape == (nq, nc):
-            subs = "qc"
+        if coef_shape == (nc, nq):
+            subs = "cq"
         elif coef_shape == (nq, ):
             subs = "q"
         elif coef_shape == (nc, ):
             subs = "c"
         else:
-            raise RuntimeError(f"The shape of the coef should be ({nq}, {nc}), "
+            raise RuntimeError(f"The shape of the coef should be ({nc}, {nq}), "
                                f"({nq}) or ({nc}), but got {tuple(shape)}.")
 
     return subs


### PR DESCRIPTION
### Update
- 按照先前讨论的 FEALPy 轴顺序约定修改了 torch 模块中的轴顺序，主要修改为交换了 NC 和 NQ 轴。把 NC 放在 NQ 前面，先排列数量较少的 NQ 再排列数量较多的 NC。
- 把网格 functional.py 文件中某些函数的 points 参数改为诸如 edge, node 的形式。
- 把 integrator 替换成 quadrature_formula，并在原来的名称下以 logger 发出弃用警告。