### PR TITLE
fixbug(functionspace): remove named axis from Function __new__

### DIFF
--- a/fealpy/torch/functionspace/space.py
+++ b/fealpy/torch/functionspace/space.py
@@ -66,14 +66,12 @@ class Function(Tensor, Generic[_FS]):
     # and subject to change. Please do not use them for anything important until
     # they are released as stable.
     @staticmethod
-    def __new__(cls, space: _FS, tensor: Tensor, dof_dim: int) -> Tensor:
+    def __new__(cls, space: _FS, tensor: Tensor) -> Tensor:
         assert isinstance(space, _FunctionSpace)
         tensor = tensor.to(device=space.device, dtype=space.ftype)
-        names = [None] * tensor.ndim
-        names[dof_dim] = 'gdof'
-        return Tensor._make_subclass(cls, tensor).refine_names(*names)
+        return Tensor._make_subclass(cls, tensor)
 
-    def __init__(self, space: _FS, tensor: Tensor, dof_dim: int) -> None:
+    def __init__(self, space: _FS, tensor: Tensor) -> None:
         self.space = space
 
     def __call__(self, bc: Tensor, index=_S) -> Tensor:

--- a/fealpy/torch/functionspace/tensor_space.py
+++ b/fealpy/torch/functionspace/tensor_space.py
@@ -1,0 +1,12 @@
+
+import torch
+
+from .space import FunctionSpace
+
+_Size = torch.Size
+
+
+class TensorFunctionSpace(FunctionSpace):
+    def __init__(self, scalar_space: FunctionSpace, shape: _Size) -> None:
+        self.scalar_space = scalar_space
+        self.shape = shape


### PR DESCRIPTION
Refactor the __new__ method of the Function class within the functionspace module to no longer require the dof_dim parameter.