### PR TITLE
feat(torch.functionspace): implement the tensor basis for tensor function space

### DIFF
--- a/fealpy/torch/functionspace/functional.py
+++ b/fealpy/torch/functionspace/functional.py
@@ -1,11 +1,10 @@
 
 from typing import Tuple
 
-import torch
+from torch import tensordot
 
+from ..typing import Tensor
 from .utils import tensor_basis
-
-Tensor = torch.Tensor
 
 
 def generate_tensor_basis(basis: Tensor, shape: Tuple[int, ...], dof_priority=True) -> Tensor:
@@ -22,7 +21,7 @@ def generate_tensor_basis(basis: Tensor, shape: Tuple[int, ...], dof_priority=Tr
         where numel is the number of elements in the shape.
     """
     factor = tensor_basis(shape, dtype=basis.dtype, device=basis.device)
-    tb = torch.tensordot(basis, factor, dims=0)
+    tb = tensordot(basis, factor, dims=0)
     ldof = basis.shape[-1]
     numel = factor.shape[0]
 

--- a/fealpy/torch/functionspace/functional.py
+++ b/fealpy/torch/functionspace/functional.py
@@ -1,0 +1,33 @@
+
+from typing import Tuple
+
+import torch
+
+from .utils import tensor_basis
+
+Tensor = torch.Tensor
+
+
+def generate_tensor_basis(basis: Tensor, shape: Tuple[int, ...], dof_priority=True) -> Tensor:
+    """Generate tensor basis from scalar basis.
+
+    Parameters:
+        basis (Tensor): Basis of a scalar space, shaped (..., ldof).\n
+        shape (Tuple[int, ...]): Shape of the dof.\n
+        dof_priority (bool, optional): If True, the degrees of freedom are ranked\
+        prior to their components. Defaults to True.
+
+    Returns:
+        Tensor: Basis of the tensor space, shaped (..., ldof*numel, *shape),\
+        where numel is the number of elements in the shape.
+    """
+    factor = tensor_basis(shape, dtype=basis.dtype, device=basis.device)
+    tb = torch.tensordot(basis, factor, dims=0)
+    ldof = basis.shape[-1]
+    numel = factor.shape[0]
+
+    if dof_priority:
+        ndim = len(shape)
+        tb = tb.transpose(-ndim-1, -ndim-2)
+
+    return tb.reshape(basis.shape[:-1] + (numel*ldof,) + shape)

--- a/fealpy/torch/functionspace/space.py
+++ b/fealpy/torch/functionspace/space.py
@@ -1,20 +1,16 @@
 
 from typing import Union, Callable, Optional, Generic, TypeVar
-from abc import ABCMeta, abstractmethod
 
 import torch
-from torch import Tensor
 
-Index = Union[int, slice, Tensor]
-Number = Union[int, float]
-_S = slice(None)
+from ..typing import Tensor, _dtype, _device, Index, Number, _S
 
 
 class _FunctionSpace():
-    r"""THe base class of function spaces"""
-    device: torch.device
-    ftype: torch.dtype
-    itype: torch.dtype
+    r"""The base class of function spaces"""
+    device: _device
+    ftype: _dtype
+    itype: _dtype
 
     # basis
 

--- a/fealpy/torch/functionspace/tensor_space.py
+++ b/fealpy/torch/functionspace/tensor_space.py
@@ -1,9 +1,7 @@
 
 from typing import Tuple
 
-from fealpy.torch.functionspace.space import _S
-
-from ..typing import Tensor, Size
+from ..typing import Tensor, Size, _S
 from .functional import generate_tensor_basis
 from .space import FunctionSpace, _S, Index
 from .utils import to_tensor_dof
@@ -16,7 +14,9 @@ class TensorFunctionSpace(FunctionSpace):
         self.shape = Size(shape)
         self.dof_last = dof_last
 
-        self.mesh = scalar_space.mesh
+    @property
+    def mesh(self):
+        return self.scalar_space.mesh
 
     @property
     def dof_numel(self) -> int:

--- a/fealpy/torch/functionspace/tensor_space.py
+++ b/fealpy/torch/functionspace/tensor_space.py
@@ -1,61 +1,68 @@
 
-import torch
+from typing import Tuple
 
 from fealpy.torch.functionspace.space import _S
 
+from ..typing import Tensor, Size
+from .functional import generate_tensor_basis
 from .space import FunctionSpace, _S, Index
-from . import utils as U
-
-_Size = torch.Size
-Tensor = torch.Tensor
+from .utils import to_tensor_dof
 
 
 class TensorFunctionSpace(FunctionSpace):
-    def __init__(self, scalar_space: FunctionSpace, shape: _Size, *,
+    def __init__(self, scalar_space: FunctionSpace, shape: Tuple[int, ...], *,
                  dof_last: bool=True) -> None:
         self.scalar_space = scalar_space
-        self.shape = torch.Size(shape)
+        self.shape = Size(shape)
         self.dof_last = dof_last
 
         self.mesh = scalar_space.mesh
 
     @property
-    def ndim_dof(self) -> int:
+    def dof_numel(self) -> int:
         return self.shape.numel()
 
+    @property
+    def dof_ndim(self) -> int:
+        return len(self.shape)
+
     def number_of_global_dofs(self) -> int:
-        return self.ndim_dof * self.scalar_space.number_of_global_dofs()
+        return self.dof_numel * self.scalar_space.number_of_global_dofs()
 
     def number_of_local_dofs(self, doftype='cell') -> int:
-        return self.ndim_dof * self.scalar_space.number_of_local_dofs(doftype)
+        return self.dof_numel * self.scalar_space.number_of_local_dofs(doftype)
 
     def basis(self, p: Tensor, index: Index=_S, **kwargs) -> Tensor:
         phi = self.scalar_space.basis(p, index, **kwargs) # (NC, NQ, ldof)
-        # TODO: finish this
-        pass
+        return generate_tensor_basis(phi, self.shape, self.dof_last)
 
     def grad_basis(self, p: Tensor, index: Index=_S, **kwargs) -> Tensor:
         gphi = self.scalar_space.grad_basis(p, index, **kwargs)
         # TODO: finish this
         pass
 
-    def strain(self, p: Tensor, index: Index=_S, **kwargs) -> Tensor:
-        """_summary_
-
-        Parameters:
-            p (Tensor): Inputs for the grad_basis.\n
-            index (Index, optional): indices of entities.
+    def cell_to_dof(self) -> Tensor:
+        """Get the cell to dof mapping.
 
         Returns:
-            Tensor: _description_
+            Tensor: Cell to dof mapping, shaped (NC, ldof*dof_numel).
         """
-        gphi = self.scalar_space.grad_basis(p, index, **kwargs)
-        ldof, GD = gphi.shape[-2:]
+        return to_tensor_dof(
+            self.scalar_space.cell_to_dof(),
+            self.dof_numel,
+            self.scalar_space.number_of_global_dofs(),
+            self.dof_last
+        )
 
-        if self.dof_last:
-            indices = U.flatten_indices((ldof, GD), (1, 0))
-        else:
-            indices = U.flatten_indices((ldof, GD), (0, 1))
+    def face_to_dof(self) -> Tensor:
+        """Get the face to dof mapping.
 
-        return torch.cat([U.normal_strain(gphi, indices),
-                            U.shear_strain(gphi, indices)], dim=-2)
+        Returns:
+            Tensor: Face to dof mapping, shaped (NF, ldof*dof_numel).
+        """
+        return to_tensor_dof(
+            self.scalar_space.face_to_dof(),
+            self.dof_numel,
+            self.scalar_space.number_of_global_dofs(),
+            self.dof_last
+        )

--- a/fealpy/torch/functionspace/utils.py
+++ b/fealpy/torch/functionspace/utils.py
@@ -1,10 +1,11 @@
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
 from ..typing import Tensor
 from ..typing import Size
+from ..typing import _dtype, _device
 
 
 def flatten_indices(shape: Size, permute: Size) -> Tensor:
@@ -51,7 +52,8 @@ def to_tensor_dof(to_dof: Tensor, dof_numel: int, gdof: int, dof_priority: bool=
     return indices[to_dof].reshape(num_entity, -1)
 
 
-def tensor_basis(shape: Tuple[int, ...], *, dtype=None, device=None) -> Tensor:
+def tensor_basis(shape: Tuple[int, ...], *, dtype: Optional[_dtype]=None,
+                 device: Union[str, _device, None]=None) -> Tensor:
     """Generate tensor basis with 0-1 elements.
 
     Parameters:

--- a/fealpy/torch/functionspace/utils.py
+++ b/fealpy/torch/functionspace/utils.py
@@ -1,13 +1,13 @@
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
-Tensor = torch.Tensor
-_Size = torch.Size
+from ..typing import Tensor
+from ..typing import Size
 
 
-def flatten_indices(shape: _Size, permute: _Size) -> Tensor:
+def flatten_indices(shape: Size, permute: Size) -> Tensor:
     """Construct indices of elements in the flattened tensor.
 
     Parameters:
@@ -24,6 +24,46 @@ def flatten_indices(shape: _Size, permute: _Size) -> Tensor:
     for d in range(len(permute)):
         inv_permute[permute[d]] = d
     return permuted_indices.permute(inv_permute)
+
+
+def to_tensor_dof(to_dof: Tensor, dof_numel: int, gdof: int, dof_priority: bool=True):
+    """Expand the relationship between entity and scalar dof to the tensor dof.
+
+    Parameters:
+        to_dof (Tensor): Entity to the scalar dof.\n
+        dof_numel (int): Number of dof elements.\n
+        gdof (int): total number of dofs.\n
+        dof_priority (bool, optional): If True, the degrees of freedom are ranked\
+        prior to their components. Defaults to True.
+
+    Returns:
+        Tensor: Global indices of tensor dofs in each entity.
+    """
+    kwargs = {'dtype': to_dof.dtype, 'device': to_dof.device}
+    num_entity = to_dof.shape[0]
+    indices = torch.arange(gdof*dof_numel, **kwargs)
+
+    if dof_priority:
+        indices = indices.reshape(dof_numel, gdof).T
+    else:
+        indices = indices.reshape(gdof, dof_numel)
+
+    return indices[to_dof].reshape(num_entity, -1)
+
+
+def tensor_basis(shape: Tuple[int, ...], *, dtype=None, device=None) -> Tensor:
+    """Generate tensor basis with 0-1 elements.
+
+    Parameters:
+        shape (Tuple[int, ...]): Shape of each tensor basis.
+
+    Returns:
+        Tensor: Tensor basis shaped (numel, *shape).
+    """
+    kwargs = {'dtype': dtype, 'device': device}
+    shape = torch.Size(shape)
+    numel = shape.numel()
+    return torch.eye(numel, **kwargs).reshape((numel,) + shape)
 
 
 def normal_strain(gphi: Tensor, indices: Tensor, *, out: Optional[Tensor]=None) -> Tensor:

--- a/fealpy/torch/typing.py
+++ b/fealpy/torch/typing.py
@@ -1,13 +1,17 @@
 
-from typing import Tuple
+from typing import Tuple, Union
 from functools import reduce
 
 import torch
 
 
+### Types
+
 Tensor = torch.Tensor
+Index = Union[int, slice, Tuple[int, ...], Tensor]
 _dtype = torch.dtype
 _device = torch.device
+DeviceLike = Union[str, _device]
 
 _bool = torch.bool
 _int = torch.int
@@ -20,6 +24,13 @@ _float64 = torch.float16
 _float32 = torch.float32
 _float64 = torch.float64
 _uint8 = torch.uint8
+
+Number = Union[int, float]
+
+
+### Constants
+
+_S = slice(None)
 
 
 class Size(Tuple[int, ...]):

--- a/fealpy/torch/typing.py
+++ b/fealpy/torch/typing.py
@@ -1,0 +1,27 @@
+
+from typing import Tuple
+from functools import reduce
+
+import torch
+
+
+Tensor = torch.Tensor
+_dtype = torch.dtype
+_device = torch.device
+
+_bool = torch.bool
+_int = torch.int
+_int8 = torch.int8
+_int16 = torch.int16
+_int32 = torch.int32
+_int64 = torch.int64
+_float = torch.float
+_float64 = torch.float16
+_float32 = torch.float32
+_float64 = torch.float64
+_uint8 = torch.uint8
+
+
+class Size(Tuple[int, ...]):
+    def numel(self) -> int:
+        return reduce(lambda x, y: x * y, self, 1)

--- a/test/torch/functionspace/test_functional.py
+++ b/test/torch/functionspace/test_functional.py
@@ -1,0 +1,73 @@
+
+import torch
+
+from fealpy.torch.functionspace.functional import generate_tensor_basis
+
+
+def test_generate_tensor_basis():
+    basis = torch.tensor([[1, 2, 3], ], dtype=torch.float64)
+    result = generate_tensor_basis(basis, (2, 2), dof_priority=False)
+    expected = torch.tensor(
+        [[
+            [[1, 0],
+             [0, 0]],
+            [[0, 1],
+             [0, 0]],
+            [[0, 0],
+             [1, 0]],
+            [[0, 0],
+             [0, 1]],
+            [[2, 0],
+             [0, 0]],
+            [[0, 2],
+             [0, 0]],
+            [[0, 0],
+             [2, 0]],
+            [[0, 0],
+             [0, 2]],
+            [[3, 0],
+             [0, 0]],
+            [[0, 3],
+             [0, 0]],
+            [[0, 0],
+             [3, 0]],
+            [[0, 0],
+             [0, 3]]
+        ]],
+        dtype=torch.float64
+    )
+
+    basis = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float64)
+    result = generate_tensor_basis(basis, (2, 2), dof_priority=True)
+    expected = torch.tensor(
+        [[
+            [[1, 0], [0, 0]],
+            [[2, 0], [0, 0]],
+            [[3, 0], [0, 0]],
+            [[0, 1], [0, 0]],
+            [[0, 2], [0, 0]],
+            [[0, 3], [0, 0]],
+            [[0, 0], [1, 0]],
+            [[0, 0], [2, 0]],
+            [[0, 0], [3, 0]],
+            [[0, 0], [0, 1]],
+            [[0, 0], [0, 2]],
+            [[0, 0], [0, 3]]
+        ],[
+            [[4, 0], [0, 0]],
+            [[5, 0], [0, 0]],
+            [[6, 0], [0, 0]],
+            [[0, 4], [0, 0]],
+            [[0, 5], [0, 0]],
+            [[0, 6], [0, 0]],
+            [[0, 0], [4, 0]],
+            [[0, 0], [5, 0]],
+            [[0, 0], [6, 0]],
+            [[0, 0], [0, 4]],
+            [[0, 0], [0, 5]],
+            [[0, 0], [0, 6]]
+        ]],
+        dtype=torch.float64
+    )
+
+    assert torch.allclose(result, expected)

--- a/test/torch/functionspace/test_utils.py
+++ b/test/torch/functionspace/test_utils.py
@@ -3,6 +3,8 @@ import torch
 
 from fealpy.torch.functionspace.utils import (
     flatten_indices,
+    to_tensor_dof,
+    tensor_basis,
     normal_strain,
     shear_strain
 )
@@ -23,6 +25,63 @@ def test_flatten_indices():
     )
 
     assert torch.equal(indices, expected)
+
+
+def test_to_tensor_dof():
+    to_dof = torch.tensor([[0, 1, 2],
+                           [2, 3, 4],
+                           [4, 5, 6],
+                           [6, 7, 8]])
+    dof_numel = 3
+    gdof = 9
+    result = to_tensor_dof(to_dof, dof_numel, gdof, dof_priority=False)
+    expected = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7, 8],
+         [6, 7, 8, 9, 10, 11, 12, 13, 14],
+         [12, 13, 14, 15, 16, 17, 18, 19, 20],
+         [18, 19, 20, 21, 22, 23, 24, 25, 26]]
+    )
+
+    assert torch.equal(result, expected)
+
+    result = to_tensor_dof(to_dof, dof_numel, gdof, dof_priority=True)
+    expected = torch.tensor(
+        [[0, 9, 18, 1, 10, 19, 2, 11, 10],
+         [2, 11, 20, 3, 12, 21, 4, 13, 22],
+         [4, 13, 22, 5, 14, 23, 6, 15, 24],
+         [6, 15, 24, 7, 16, 25, 8, 27, 26]]
+    )
+
+
+def test_tensor_basis():
+    result = tensor_basis((2, 3), dtype=torch.float32)
+    expected = torch.tensor(
+        [[[1, 0, 0],
+          [0, 0, 0]],
+         [[0, 1, 0],
+          [0, 0, 0]],
+         [[0, 0, 1],
+          [0, 0, 0]],
+         [[0, 0, 0],
+          [1, 0, 0]],
+         [[0, 0, 0],
+          [0, 1, 0]],
+         [[0, 0, 0],
+          [0, 0, 1]]],
+          dtype=torch.float32
+    ) # (6, 2, 3)
+
+    assert torch.allclose(result, expected)
+
+    result = tensor_basis((3, ), dtype=torch.float32)
+    expected = torch.tensor(
+        [[1, 0, 0],
+         [0, 1, 0],
+         [0, 0, 1]],
+          dtype=torch.float32
+    ) # (6, 3)
+
+    assert torch.allclose(result, expected)
 
 
 def test_normal_strain():


### PR DESCRIPTION
### New
- Implement the basis for tensor function space. (Note: the grad_basis is still is progress...)

### Update
- Move some types into fealpy/torch/typing.py