### PR TITLE
refactor(functional): update integration functions and utils for clarity

### DIFF
--- a/fealpy/experimental/functional.py
+++ b/fealpy/experimental/functional.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 from .backend import backend_manager as bm
 from .typing import TensorLike, CoefLike
-
-from .utils import is_scalar, is_tensor, get_coef_subscripts
+from .utils import is_scalar, is_tensor, fill_axis
 
 
 def integral(value: TensorLike, weights: TensorLike, measure: TensorLike, *,
@@ -25,82 +24,79 @@ def integral(value: TensorLike, weights: TensorLike, measure: TensorLike, *,
     return bm.einsum(f'c, q, ...cq -> {subs}', measure, weights, value)
 
 
-def linear_integral(input: TensorLike, weights: TensorLike, measure: TensorLike,
-                    coef: Optional[CoefLike]=None,
+def linear_integral(basis: TensorLike, weights: TensorLike, measure: TensorLike,
+                    source: Optional[CoefLike]=None,
                     batched: bool=False) -> TensorLike:
     """Numerical integration.
 
     Parameters:
-        input (TensorLike[C, Q, I]): The values on the quadrature points to be integrated.
+        basis (TensorLike[C, Q, I, ...]): The values on the quadrature points to be integrated.
         weights (TensorLike[Q,]): The weights of the quadrature points.
-        measure (TensorLike[C,]): The measure of the quadrature points.
-        coef (Number, TensorLike, optional): The coefficient of the integration. Defaults to None.
-            Must be int, float, TensorLike, or callable returning TensorLike with shape (Q,), (C,) or (C, Q).
-            If `batched == True`, the shape of the coef should be (B, Q, C) or (B, C).
-        batched (bool, optional): Whether the coef are batched. Defaults to False.
+        measure (TensorLike[C,]): The measure of the mesh entity.
+        source (Number, TensorLike, optional): The source of the integration. Defaults to None.
+            Must be int, float, TensorLike, or callable returning TensorLike with shape (C,), (C, Q) or (C, Q, ...).
+            If `batched == True`, there should be a batch dimension as the first axis.
+        batched (bool, optional): Whether the source are batched. Defaults to False.
 
     Returns:
-        TensorLike: The result of the integration shaped (C, I).
-            If `batched` is True, the shape of the result is (B, C, I).
+        TensorLike: The result of the integration shaped (C, I) for source (C, Q, ...).
+            And (C, I, ...) for source (C, ) and (C, Q).
+            If `batched` is True, there will be a batch dimension as the first axis.
     """
-    if coef is None:
-        return bm.einsum('c, q, cqi -> ci', measure, weights, input)
+    if source is None:
+        return bm.einsum('c, q, cq... -> c...', measure, weights, basis)
 
-    NQ = weights.shape[0]
-    NC = measure.shape[0]
+    if is_scalar(source):
+        return bm.einsum('c, q, cq... -> c...', measure, weights, basis) * source
 
-    if is_scalar(coef):
-        return bm.einsum('c, q, cqi -> ci', measure, weights, input) * coef
-    elif is_tensor(coef):
-        out_subs = 'bci' if batched else 'ci'
-        subs = get_coef_subscripts(coef.shape, NQ, NC, batched)
-        return bm.einsum(f'c, q, cqi, {subs} -> {out_subs}', measure, weights, input, coef)
+    elif is_tensor(source):
+        basis = basis.reshape(*basis.shape[:3], -1) # (C, Q, I, dof_numel)
+
+        if source.ndim <= 2 + int(batched):
+            dof_shape = basis.shape[3:]
+            source = fill_axis(source, 3 if batched else 2)
+            r = bm.einsum(f'c, q, cqid, ...cq -> ...cid', measure, weights, basis, source)
+            return bm.reshape(r, r.shape[:-1] + dof_shape)
+        else:
+            source = fill_axis(source, 4 if batched else 3)
+            return bm.einsum(f'c, q, cqid, ...cqd -> ...ci', measure, weights, basis, source)
+
     else:
-        raise TypeError(f"coef should be int, float or TensorLike, but got {type(coef)}.")
+        raise TypeError(f"source should be int, float or TensorLike, but got {type(source)}.")
 
 
-def bilinear_integral(input1: TensorLike, input2: TensorLike, weights: TensorLike,
+def bilinear_integral(basis1: TensorLike, basis2: TensorLike, weights: TensorLike,
                       measure: TensorLike,
                       coef: Optional[CoefLike]=None,
                       batched: bool=False) -> TensorLike:
     """Numerical integration.
 
     Parameters:
-        input1 (TensorLike[C, Q, I, ...]): The values on the quadrature points to be integrated.
-        input2 (TensorLike[C, Q, J, ...]): The values on the quadrature points to be integrated.
+        basis1 (TensorLike[C, Q, I, ...]): The values on the quadrature points to be integrated.
+        basis2 (TensorLike[C, Q, J, ...]): The values on the quadrature points to be integrated.
         weights (TensorLike[Q,]): The weights of the quadrature points.
-        measure (TensorLike[C,]): The measure of the quadrature points.
+        measure (TensorLike[C,]): The measure of the mesh entity.
         coef (Number, TensorLike, optional): The coefficient of the integration. Defaults to None.
-            Must be int, float, TensorLike, or callable returning TensorLike with shape (Q,), (C,) or (C, Q).
-            If `batched == True`, the shape of the coef should be (B, C, Q) or (B, C).
+            Must be int, float, TensorLike, or callable returning TensorLike with shape (C,), (C, Q) or (C, Q, ...).
+            If `batched == True`, there should be a batch dimension as the first axis.
         batched (bool, optional): Whether the coef are batched. Defaults to False.
 
     Returns:
         TensorLike: The result of the integration shaped (C, I, J).
             If `batched` is True, the shape of the output is (B, C, I, J).
     """
-    if len(input1.shape)==5:
-        input1sub = 'cqidl'
-        input2sub = 'cqjdl'
+    basis1 = basis1.reshape(*basis1.shape[:3], -1) # (C, Q, I, dof_numel)
+    basis2 = basis2.reshape(*basis2.shape[:3], -1) # (C, Q, J, dof_numel)
 
-    elif len(input1.shape)==4:
-        input1sub = 'cqid'
-        input2sub = 'cqjd'
-    else:
-        input1sub = 'cqi'
-        input2sub = 'cqj'
-
-    NQ = weights.shape[0]
-    NC = measure.shape[0]
-    
     if coef is None:
-        return bm.einsum(f'q, c, {input1sub}, {input2sub} -> cij', weights, measure, input1, input2)
-    
+        return bm.einsum(f'q, c, cqid, cqjd -> cij', weights, measure, basis1, basis2)
+
     if is_scalar(coef):
-        return bm.einsum(f'q, c, {input1sub}, {input2sub} -> cij', weights, measure, input1, input2) * coef
+        return bm.einsum(f'q, c, cqid, cqjd -> cij', weights, measure, basis1, basis2) * coef
+
     elif is_tensor(coef):
-        out_subs = 'cij'
-        subs = get_coef_subscripts(coef.shape, NQ, NC)
-        return bm.einsum(f'q, c, {input1sub}, {input2sub}, {subs} -> {out_subs}', weights, measure, input1, input2, coef)
+        coef = fill_axis(coef, 4 if batched else 3)
+        return bm.einsum(f'q, c, cqid, cqjd, ...cqd -> ...cij', weights, measure, basis1, basis2, coef)
+
     else:
-        raise TypeError(f"coef should be int, float or Tensor, but got {type(coef)}.")
+        raise TypeError(f"coef should be int, float or TensorLike, but got {type(coef)}.")

--- a/fealpy/experimental/utils.py
+++ b/fealpy/experimental/utils.py
@@ -51,6 +51,18 @@ def is_tensor(input: Union[int, float, TensorLike]) -> bool:
     return False
 
 
+def fill_axis(input: TensorLike, ndim: int):
+    diff = ndim - input.ndim
+
+    if diff > 0:
+        return bm.reshape(input, input.shape + (1, ) * diff)
+    elif diff == 0:
+        return input
+    else:
+        raise RuntimeError(f"The dimension of the input should be smaller than {ndim}, "
+                           f"but got shape {tuple(input.shape)}.")
+
+
 def get_coef_subscripts(shape: TensorLike, nq: int, nc: int, batched: bool):
     if batched:
         coef_shape = shape[1:]


### PR DESCRIPTION
### Update

更新了 functional.py 中的 linear_integral 和 bilinear_integral 函数，现在可以支持任意形状的张量基函数积分。

Rename input arguments for linear_integral and bilinear_integral functions to clarify their purposes. Replace 'input' with 'basis' and 'coef' with 'source' to better reflect the mathematical operations being performed. Additionally, introduce 'fill_axis' utility function to ensure tensors have the required number of dimensions, improving code readability and reducing dimension-related errors.
