### PR TITLE
feat(mesh, geometry): Add interface mesh generator in TriangleMesh and fix bug

### DIFF
--- a/fealpy/experimental/backend/base.py
+++ b/fealpy/experimental/backend/base.py
@@ -27,6 +27,14 @@ class TensorLike(metaclass=ABCMeta):
 
     def __len__(self) -> int: raise NotImplementedError
     def __getitem__(self, index: Any) -> 'TensorLike': raise NotImplementedError
+    def __eq__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __ne__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __add__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __sub__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __mul__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __truediv__(self, other: Any) -> 'TensorLike': raise NotImplementedError
+    def __matmul__(self, other: 'TensorLike') -> 'TensorLike': raise NotImplementedError
+    def __pow__(self, other: Any) -> 'TensorLike': raise NotImplementedError
     @overload
     def reshape(self, newshape: Size, /) -> 'TensorLike': raise NotImplementedError
     @overload

--- a/fealpy/experimental/geometry/__init__.py
+++ b/fealpy/experimental/geometry/__init__.py
@@ -1,2 +1,2 @@
-from .domain import Domain
-from .sizing_function import huniform
+# from .domain import Domain
+# from .sizing_function import huniform


### PR DESCRIPTION
### New
- Add `find_cut_point` in the Geometry module.
- Add `is_cut_cell` and `find_interface_node` in UniformMesh2d.
- Add `interfacemesh_generator` in TriangleMesh.

### Update
- Improve performance of interface mesh generation.
- Fixed the problem that when the interface passes through two vertices of an edge, the units on both sides will be missing.