### PR TITLE
[Feat] lagrange_triangele_mesh、parametric_lagrange_fe_space、scalar_source_integrator 中 isopara_assembly 函数

### DIFF
--- a/fealpy/fem/scalar_source_integrator.py
+++ b/fealpy/fem/scalar_source_integrator.py
@@ -60,6 +60,8 @@ class ScalarSourceIntegrator(LinearInt, SrcInt, CellInt):
         f = self.source
         mesh = getattr(space, 'mesh', None)
         bcs, ws, phi, cm, index = self.fetch(space)
+        NQ = len(ws)
+        NC = mesh.number_of_cells()
 
         rm = space.mesh.reference_cell_measure()
         J = space.mesh.jacobi_matrix(bcs)
@@ -67,5 +69,15 @@ class ScalarSourceIntegrator(LinearInt, SrcInt, CellInt):
         d = bm.sqrt(bm.linalg.det(G))
 
         val = process_coef_func(f, bcs=bcs, mesh=mesh, etype='cell', index=index)
-        M = bm.einsum('q, cq, cql, cq -> cl', ws*rm, val, phi, d)
-        return M
+        if val is None:
+            return bm.einsum('q, cql, cq -> cl ', ws*rm, phi, d) 
+
+        if isinstance(val, (int, float)):
+            return bm.einsum('q, cql, cq -> cl', ws*rm, phi, d)*val
+        elif isinstance(val, TensorLike):
+            if val.shape == (NC, ): # 分片常数
+                return bm.einsum('q, c, cql, cq -> cl', ws*rm, val, phi, d)
+            elif val.shape == (NC, NQ):
+                return bm.einsum('q, cq, cql, cq -> cl', ws*rm, val, phi, d)
+            else:
+                raise ValueError(f"I can not deal with {f.shape}!")

--- a/fealpy/mesh/lagrange_triangle_mesh.py
+++ b/fealpy/mesh/lagrange_triangle_mesh.py
@@ -116,7 +116,7 @@ class LagrangeTriangleMesh(HomogeneousMesh):
         lmesh.linearmesh = mesh
 
         lmesh.edge2cell = mesh.edge2cell # (NF, 4)
-        lmesh.cell2edge = mesh.cell_to_edge()
+        lmesh.cell2edge = mesh.cell2edge
         lmesh.edge  = mesh.edge_to_ipoint(p)
         return lmesh
 
@@ -134,9 +134,39 @@ class LagrangeTriangleMesh(HomogeneousMesh):
         lmesh.linearmesh = mesh
 
         lmesh.edge2cell = mesh.edge2cell # (NF, 4)
-        lmesh.cell2edge = mesh.cell_to_edge()
+        lmesh.cell2edge = mesh.cell2edge
         lmesh.edge  = mesh.edge_to_ipoint(p)
         return lmesh 
+
+    def uniform_refine(self , n:int = 1 ):
+        """
+        @brief 高阶网格一致加密方法
+        @param n: int, 加密次数
+        """
+        ref_mesh = TriangleMesh.from_one_triangle()
+        ref_node = ref_mesh.node
+        ref_cell = ref_mesh.cell
+        ref_mesh.uniform_refine(n)
+        Lg_ref_node = ref_mesh.interpolation_points(self.p)
+        Lg_ref_cell = ref_mesh.cell_to_ipoint(self.p)
+        v = ref_node[ref_cell] - Lg_ref_node[:,None,:]
+        a0 = 0.5 * bm.abs(bm.cross(v[:, 1, :], v[:, 2, :]))
+        a1 = 0.5 * bm.abs(bm.cross(v[:, 0, :], v[:, 2, :]))
+        a2 = 0.5 * bm.abs(bm.cross(v[:, 0, :], v[:, 1, :]))
+        re = bm.zeros((len(Lg_ref_node),3), dtype = self.ftype)
+        re = bm.set_at(re, (...,0), 2*a0)
+        re = bm.set_at(re, (...,1), 2*a1)
+        re = bm.set_at(re, (...,2), 2*a2)
+        self.linearmesh.uniform_refine(n)
+        phi = self.shape_function(re , variables= "u")[None,...]
+        nen = bm.einsum('cql, cld -> cqd', phi, self.node[self.cell])
+        self.cell = self.linearmesh.cell_to_ipoint(self.p)
+        c = nen[:,Lg_ref_cell,:].transpose(1,0,2,3).reshape(-1,self.cell.shape[-1], self.GD)
+        kwargs = bm.context(self.node)
+        new_node = bm.zeros((bm.max(self.cell)+1,self.node.shape[-1]),**kwargs)
+        new_node = bm.set_at(new_node, self.cell, c)
+        self.node = new_node
+        self.construct()
 
     # quadrature
     def quadrature_formula(self, q: int, etype: Union[int, str]='cell'):

--- a/test/mesh/test_lagrange_triangle_mesh.py
+++ b/test/mesh/test_lagrange_triangle_mesh.py
@@ -65,13 +65,30 @@ class TestLagrangeTriangleMeshInterfaces:
         lmesh = LagrangeTriangleMesh.from_triangle_mesh(mesh, p=3, surface=sphere)
         fname = f"sphere_test.vtu"
         lmesh.to_vtk(fname=fname)
+    
+    @pytest.mark.parametrize("backend", ['numpy'])
+    def test_uniform_refine(self, backend):
+        bm.set_backend(backend)
+
+        sphere = SphereSurface()
+        mesh = TriangleMesh.from_unit_sphere_surface()
         
+        maxit = 5
+        for i in range(maxit):
+            lmesh = LagrangeTriangleMesh.from_triangle_mesh(mesh, p=3, surface=sphere)
+            
+            fname = f"sp{i}_test.vtu"
+            lmesh.to_vtk(fname=fname)
+
+            if i < maxit-1:
+                mesh.uniform_refine()
+                
     @pytest.mark.parametrize("backend", ['numpy'])
     def test_curve_mesh(self, backend):
         bm.set_backend(backend)
 
         circle = CircleCurve()
-        mesh = TriangleMesh.from_unit_circle_gmesh(h=0.3)
+        mesh = TriangleMesh.from_unit_circle_gmsh(h=0.3)
 
         lmesh = LagrangeTriangleMesh.from_curve_triangle_mesh(mesh, p=2, curve=circle)
 
@@ -143,12 +160,6 @@ class TestLagrangeTriangleMeshInterfaces:
 
 
 if __name__ == "__main__":
-    a = TestLagrangeTriangleMeshInterfaces()
-    #a.test_init_mesh(init_data[0], 'numpy')
-    #a.test_from_triangle_mesh(from_triangle_mesh_data[0], 'numpy')
-    #a.test_surface_mesh('numpy')
-    a.test_curve_mesh('numpy')
-    #a.test_cell_area(cell_area_data[0], 'numpy')
-    #a.test_(cell_[0], 'numpy')
-    #a.test_error('numpy')
-    #pytest.main(["./test_lagrange_triangle_mesh.py"])
+    #a = TestLagrangeTriangleMeshInterfaces()
+    #a.test_uniform_refine('numpy')
+    pytest.main(["./test_lagrange_triangle_mesh.py"])


### PR DESCRIPTION
1、lagrange_triangle_mesh 增加 uniform_refine 函数。
2、parametric_lagrange_fe_space 中修改 interpolate 函数中ips的计算，插值点用 mesh.node，增加 boundary_interpolate 函数。
3、scalar_source_integrator 中 isopara_assembly 函数，增加当 f 是不同类型时右端项的计算。
4、test_lagrange_triangle_mesh 增加 test_unifrom_refine。 