### PR TITLE
fix(backend): add '_remove_device' and temporarily remove the 'device' to ensure the JAX code. fix(fem): change slice assignment to 'bm.set_at'. fix(sparse): change slice assignment to 'bm.set_at'. fix(sparse): resolve conflict issue of simultaneously modfying 'coo_tensor.py'.

### DIFF
--- a/fealpy/backend/numpy_backend.py
+++ b/fealpy/backend/numpy_backend.py
@@ -16,14 +16,12 @@ from .base import (
     ATTRIBUTE_MAPPING, FUNCTION_MAPPING
 )
 
-
 def _remove_device(func):
     def wrapper(*args, **kwargs):
         if 'device' in kwargs:
             kwargs.pop('device')
         return func(*args, **kwargs)
     return wrapper
-
 
 class NumPyBackend(BackendProxy, backend_name='numpy'):
     DATA_CLASS = np.ndarray

--- a/fealpy/fem/dirichlet_bc.py
+++ b/fealpy/fem/dirichlet_bc.py
@@ -135,7 +135,8 @@ class DirichletBC():
         isDDof = self.is_boundary_dof
         kwargs = A.values_context()
         bdIdx = bm.zeros(A.shape[0], **kwargs)
-        bdIdx[isDDof.reshape(-1)] = 1
+        # bdIdx[isDDof.reshape(-1)] = 1
+        bdIdx = bm.set_at(bdIdx, isDDof.reshape(-1), 1)
         D0 = spdiags(1-bdIdx, 0, A.shape[0], A.shape[0])
         D1 = spdiags(bdIdx, 0, A.shape[0], A.shape[0])
         A = D0@A@D0 + D1

--- a/fealpy/sparse/_spmm.py
+++ b/fealpy/sparse/_spmm.py
@@ -63,7 +63,9 @@ def spmm_csr(crow: _DT, col: _DT, values: _DT, spshape: _Size, x: _DT) -> _DT:
         start = crow[i]
         end = crow[i + 1]
         r = bm.einsum('...i, ...ij -> ...j', values[..., start:end], x[..., col[start:end], :])
-        result[..., i, :] = r
+        # result[..., i, :] = r
+        result = bm.set_at(result, (Ellipsis, i, slice(None)), r)
+
 
     if unsqueezed:
         result = result[..., 0]

--- a/fealpy/sparse/_spspmm.py
+++ b/fealpy/sparse/_spspmm.py
@@ -107,7 +107,8 @@ def spspmm_csr(crow1: _DT, col1: _DT, values1: _DT, spshape1: _Size,
     new_values = bm.index_add(new_values, inverse_indices, values, axis=-1)
 
     for x in unique_indices[0,:]:
-        new_crow[x+1]+=1
+        # new_crow[x+1]+=1
+        new_crow = bm.set_at(new_crow, x+1, new_crow[x+1])
 
     new_crow=bm.cumsum(new_crow, axis =-1)
 

--- a/fealpy/sparse/coo_tensor.py
+++ b/fealpy/sparse/coo_tensor.py
@@ -144,10 +144,10 @@ class COOTensor(SparseTensor):
         except (AttributeError, NotImplementedError):
             pass
 
+        count = bm.bincount(self._indices[0], minlength=self._spshape[0])
+        crow = bm.cumsum(count)
+        crow = bm.concat([bm.tensor([0], **bm.context(crow)), crow])
         order = bm.argsort(self._indices[0], stable=True)
-        new_row = self._indices[0, order]
-        crow = bm.nonzero((bm.not_equal(new_row, bm.roll(new_row, 1))))[0]
-        crow = bm.concat([crow, bm.tensor([self.nnz], **bm.context(crow))])
         new_col = bm.copy(self._indices[-1, order])
 
         if self.values is None:
@@ -190,7 +190,7 @@ class COOTensor(SparseTensor):
         order = bm.lexsort(tuple(reversed(self._indices)))
         sorted_indices = self._indices[:, order]
         unique_mask = bm.concat([
-            bm.ones((1, ), dtype=bm.bool, device=bm.get_device(sorted_indices)),
+            bm.ones((1, ), dtype=bool, device=bm.get_device(sorted_indices)),
             bm.any(sorted_indices[:, 1:] - sorted_indices[:, :-1], axis=0)
         ], axis=0)
         new_indices = bm.copy(sorted_indices[..., unique_mask])
@@ -275,29 +275,30 @@ class COOTensor(SparseTensor):
         if len(coo_tensors) == 0:
             raise ValueError("coo_tensors cannot be empty")
 
-        elif len(coo_tensors) == 1:
+        if len(coo_tensors) == 1:
             return coo_tensors[0]
 
-        fcoo = coo_tensors[0]
-        total_nnz = sum(coo.nnz for coo in coo_tensors)
-        new_indices = bm.empty((fcoo.sparse_ndim, total_nnz), **bm.context(fcoo.indices))
-        new_indices[:, :fcoo.nnz] = fcoo.indices
-        nnz_cursor = fcoo.nnz
-        size_cursor = fcoo.sparse_shape[axis]
-        values_list = [fcoo.values]
+        indices_list = []
+        values_list = []
+        prev_len = 0
 
-        for coo in coo_tensors[1:]:
-            slicing = slice(nnz_cursor, nnz_cursor + coo.nnz)
-            new_indices[:, slicing] = coo.indices
-            new_indices[axis, slicing] += size_cursor
-            values_list.append(coo.values)
-            nnz_cursor += coo.nnz
-            size_cursor += coo.sparse_shape[axis]
+        for coo in coo_tensors:
+            indices = bm.copy(coo.indices)
+            indices = bm.index_add(
+                indices, bm.array([axis], device=indices.device), prev_len,
+                axis=0
+            )
+            indices_list.append(indices)
+            values_list.append(bm.copy(coo.values))
+            prev_len += coo.sparse_shape[axis]
 
-        spshape = list(fcoo.sparse_shape)
-        spshape[axis] = size_cursor
-
-        return cls(new_indices, bm.concat(values_list, axis=-1), spshape)
+        new_indices = bm.concat(indices_list, axis=1)
+        del indices_list
+        new_values = bm.concat(values_list, axis=-1)
+        del values_list
+        spshape = list(coo_tensors[-1].sparse_shape)
+        spshape[axis] = prev_len
+        return cls(new_indices, new_values, spshape)
 
     ### 6. Arithmetic Operations ###
     def neg(self) -> 'COOTensor':


### PR DESCRIPTION
## 摘要
- 由于 Jax 中设备管理的特殊，目前先类似 numpy_backend 中对于小于 2.0 版本的 numpy 一样的处理手段，手动将 device 移除，确保 Jax 后端下的程序可以正常运行

## 技术方案
- 将切片赋值的操作修改成标准的 bm.set_at。

## 其它
- 这里提交的第二个 commit 是因为同时修改了 coo_tensor.py 中的内容，导致一些地方存在冲突需要解决。