### PR TITLE
[Feat, Fix] Add speye function for sparse and fix csr_matrix bug (Sparse)

### DIFF
--- a/fealpy/sparse/__init__.py
+++ b/fealpy/sparse/__init__.py
@@ -8,7 +8,7 @@ from .sparse_tensor import SparseTensor
 from .coo_tensor import COOTensor
 from .csr_tensor import CSRTensor
 
-from .ops import spdiags
+from .ops import spdiags, speye
 
 
 
@@ -127,6 +127,9 @@ def csr_matrix(arg1,
         ftype (dtype | None, optional): Scalar type of data
         device (str | device | None, optional): _description_
     """
+    if itype is None:
+        itype = bm.int64
+
     if isinstance(arg1, _DT): # From a dense tensor
         indices_tuple = bm.nonzero(arg1)
         indices = bm.stack(indices_tuple, axis=0)

--- a/fealpy/sparse/ops.py
+++ b/fealpy/sparse/ops.py
@@ -84,3 +84,40 @@ def spdiags(data: TensorLike, diags: Union[TensorLike, int], M: int, N: int,
         return diag_tensor
 
     return diag_tensor.tocsr()
+
+@overload
+def speye(M: int, N: Optional[int] = None, diags: Union[TensorLike, int] = 0, dtype=None,
+          device = None) -> CSRTensor:...
+@overload
+def speye(M: int, N: Optional[int] = None, diags: Union[TensorLike, int] = 0, dtype=None,
+          device = None, *, format: Literal['csr']) -> CSRTensor: ... 
+@overload
+def speye(M: int, N: Optional[int] = None, diags: Union[TensorLike, int] = 0, dtype=None,
+          device = None, *, format: Literal['coo']) -> COOTensor: ... 
+def speye(M: int, N: Optional[int] = None, diags: Union[TensorLike, int] = 0, dtype=None,
+          device = None, *, format: Optional[str] = 'csr'):
+    """Return a sparse matrix with ones on diagonal
+
+    Parameters:  
+        M (int): The number of rows of the resulting sparse tensor.
+        N (int | None): The number of columns of the resulting sparse tensor.
+        diags (Tensor | int): The index or indices of the diagonals to place ones on.
+            k = 0: the main diagonal.
+            k > 0: the k-th upper diagonal.
+            k < 0: the k-th lower diagonal.
+
+        dtype: The data type of the sparse tensor elements (the ones). Defaults to bm.int64.
+        device: The device where the sparse tensor will be created (e.g., 'cpu', 'cuda').
+
+        format (str | None): The format of the resulting sparse tensor.
+    """
+    if N is None:
+        N = M
+
+    if isinstance(diags, TensorLike):
+        nd = len(diags)
+    else:
+        nd = 1
+
+    values = bm.ones((nd, M), dtype=dtype, device=device)
+    return spdiags(values, diags=diags, M=M, N=N, format=format)

--- a/test/sparse/test_operation.py
+++ b/test/sparse/test_operation.py
@@ -2,7 +2,7 @@
 import pytest
 
 from fealpy.backend import backend_manager as bm
-from fealpy.sparse.ops import spdiags
+from fealpy.sparse.ops import spdiags, speye
 
 ALL_BACKENDS = ['numpy', 'pytorch']
 
@@ -55,6 +55,63 @@ class test_spdiags():
                                   [0, 2, 3, 0, 0], 
                                   [0, 0, 3, 0, 0], 
                                   [0, 0, 0, 0, 0]], dtype=data.dtype)
+
+        assert bm.allclose(csr_diags.toarray(), expected_diag)
+        assert bm.allclose(coo_diags.toarray(), expected_diag)
+
+class test_speye():
+    @pytest.mark.parametrize("backend", ALL_BACKENDS)
+    def test_scalar_diags(self, backend):
+        bm.set_backend(backend)
+
+        dtype = bm.float64
+
+        csr_diags1 = speye(4, format='csr', dtype=dtype)
+        coo_diags1 = speye(4, format='coo', dtype=dtype)
+
+        diags = -1
+        csr_diags2 = speye(4, diags=diags, format='csr', dtype=dtype)
+        coo_diags2 = speye(4, diags=diags, format='coo', dtype=dtype)
+
+        diags = 1
+        csr_diags3 = speye(4, 5, diags=diags, format='csr', dtype=dtype)
+        coo_diags3 = speye(4, 5, diags=diags, format='coo', dtype=dtype)
+
+        expected_diag1 = bm.array([[1, 0, 0, 0], 
+                                  [0, 1, 0, 0], 
+                                  [0, 0, 1, 0], 
+                                  [0, 0, 0, 1]], dtype=dtype)
+
+        expected_diag2 = bm.array([[0, 0, 0, 0], 
+                                  [1, 0, 0, 0], 
+                                  [0, 1, 0, 0], 
+                                  [0, 0, 1, 0]], dtype=dtype)
+
+        expected_diag3 = bm.array([[0, 1, 0, 0, 0], 
+                                  [0, 0, 1, 0, 0], 
+                                  [0, 0, 0, 1, 0], 
+                                  [0, 0, 0, 0, 0]], dtype=dtype)
+
+        assert bm.allclose(csr_diags1.toarray(), expected_diag1)
+        assert bm.allclose(coo_diags1.toarray(), expected_diag1)
+        assert bm.allclose(csr_diags2.toarray(), expected_diag2)
+        assert bm.allclose(coo_diags2.toarray(), expected_diag2)
+        assert bm.allclose(csr_diags3.toarray(), expected_diag3)
+        assert bm.allclose(coo_diags3.toarray(), expected_diag3)
+
+    @pytest.mark.parametrize("backend", ALL_BACKENDS)
+    def test_tensor_speye(self, backend):
+        bm.set_backend(backend)
+        dtype = bm.float64
+        diags = bm.array([0, 1, -2])
+
+        csr_diags = speye(4, 4, diags, format='csr', dtype=dtype)
+        coo_diags = speye(4, 4, diags, format='coo', dtype=dtype)
+
+        expected_diag = bm.array([[1, 1, 0, 0], 
+                                  [0, 1, 1, 0], 
+                                  [1, 0, 1, 1], 
+                                  [0, 1, 0, 1]], dtype=dtype)
 
         assert bm.allclose(csr_diags.toarray(), expected_diag)
         assert bm.allclose(coo_diags.toarray(), expected_diag)


### PR DESCRIPTION
1. 在ops.py文件中新增了speye方法以及相应的测试，该方法用于生成稀疏单位矩阵；
2. 修复了 csr_matrix 在 values 为 None 的时候，itype 错误默认为 float64 的bug。