### PR TITLE
feat(TetrahedronMesh and TriangleMesh): add the `from_medit` function to read .mesh type data file

### DIFF
--- a/fealpy/mesh/tetrahedron_mesh.py
+++ b/fealpy/mesh/tetrahedron_mesh.py
@@ -1239,6 +1239,23 @@ class TetrahedronMesh(SimplexMesh, Plotable):
         cell = data.cells_dict['tetra']
         mesh = cls(node, cell)
         return mesh
+    
+    @classmethod
+    def from_medit(cls,file):
+        '''
+        Read medit format file (.mesh) to create tetrahedral mesh.
+        Parameters:
+            file (str): Path to the medit file.
+        Returns:
+            TetrahedronMesh: An instance of TetrahedronMesh containing the mesh
+            data.
+        '''
+        import meshio
+        data = meshio.read(file)
+        node = bm.from_numpy(data.points)
+        cell = bm.from_numpy(data.cells_dict['tetra'])
+        mesh = cls(node, cell)
+        return mesh
 
     def to_vtk(self, fname=None, etype='cell', index:Index=_S):
         from .vtk_extent import  write_to_vtu

--- a/fealpy/mesh/triangle_mesh.py
+++ b/fealpy/mesh/triangle_mesh.py
@@ -1627,6 +1627,24 @@ class TriangleMesh(SimplexMesh, Plotable):
             mesh.add_plot(ax)
             plt.show()
         return mesh
+    
+    @classmethod
+    def from_medit(cls,file):
+        '''
+        Read medit format file (.mesh) to create triangle mesh.
+        Parameters:
+            file (str): Path to the medit format file.
+        Returns:
+            TriangleMesh: An instance of TriangleMesh created from the medit
+            file.
+        '''
+        import meshio
+        data = meshio.read(file)
+        node = bm.from_numpy(data.points)
+        cell = bm.from_numpy(data.cells_dict['triangle'])
+
+        mesh = cls(node, cell)
+        return mesh
 
     @classmethod
     def from_domain_distmesh(cls, domain, maxit=100, output=False, itype=None, ftype=None, device=None):


### PR DESCRIPTION
1. add `from_medit` function to read medit format file (.mesh) to create tetrahedral mesh.Medit type data files are data files supported by CGAL and ViZiR4