### PR TITLE
draft/wilbur : Allen-Cahn model update

### DIFF
--- a/example/fem/allencahn_lfem_example.py
+++ b/example/fem/allencahn_lfem_example.py
@@ -56,9 +56,9 @@ parser.add_argument('--solve',
                     default='direct', type=str,
                     help='Solver method, default is direct, options are direct, cg')
 
-parser.add_argument('--is_volume_conservation',
-                    default=True, type=bool,
-                    help='Whether to use Lagrange multiplier, default is True')
+parser.add_argument('--lagrange_multiplier',
+                    default="implicit", type=str,
+                    help='Whether to use Lagrange multiplier, default is implicit')
 
 parser.add_argument('--mm_param',
                     default=None, type=dict,

--- a/fealpy/fem/allencahn_lfem_model.py
+++ b/fealpy/fem/allencahn_lfem_model.py
@@ -27,7 +27,6 @@ class AllenCahnLFEMModel(ComputationalModel):
                          log_level=options['log_level'])
         self.options = options
         self.assemble_method = None
-        self.is_Lag_muliplier = False
         self.pdm = PDEDataManager("allen_cahn")
         
         self.set_pde(options['pde'])
@@ -42,8 +41,9 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.set_linear_system[options['time_strategy']]()
         self.solve.set(options['solve'])
         
-        if options['is_volume_conservation']:
-            self.set_lagrange_multiplier()
+        self.set_lagrange_multiplier.set(options['lagrange_multiplier'])
+        self.lagrange_multiplier.set(options['lagrange_multiplier'])
+        self.set_lagrange_multiplier()
 
     def set_pde(self,pde: Union[AllenCahnPDEDataProtocol,str] = 'circle_interface'):
         """
@@ -143,11 +143,13 @@ class AllenCahnLFEMModel(ComputationalModel):
         pde = self.pde
         space = self.space
         self.t = t
-        self.phi0[:] = space.interpolate(lambda p:pde.init_solution(p, t=t))
+        self.phi0[:] = space.interpolate(lambda p:pde.init_condition(p, t=t))
     
+    @variantmethod('implicit')
     def set_lagrange_multiplier(self):
         """
         Set the Lagrange multiplier for the weak formulation of the Allen-Cahn equation.
+        This method directly introduces the Lagrange multiplier into the left-hand matrix for implicit solving.
         """
         from ..sparse import COOTensor
         LagLinearForm = LinearForm(self.space)
@@ -161,10 +163,31 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.A1 = COOTensor(bm.array([bm.zeros(len(LagA), dtype=bm.int32),
                                  bm.arange(len(LagA), dtype=bm.int32)]), LagA,
                                 spshape=(1, len(LagA)))
-        self.b0 = bm.array([self.mesh.integral(self.pde.init_solution)])
-        self.is_Lag_muliplier = True
+        self.b0 = bm.array([self.mesh.integral(self.pde.init_condition)])
+    
+    @set_lagrange_multiplier.register('explicit')
+    def set_lagrange_multiplier(self):
+        """
+        Set the Lagrange multiplier for the weak formulation of the Allen-Cahn equation.
+        This method differs from the implicit scheme as it requires explicitly 
+        solving the Lagrange multiplier before assembling the right-hand side
+        """
+        self.LagLinearForm = LinearForm(self.space)
+        self.Lag_SSI = ScalarSourceIntegrator(q=self.q)
+        self.LagLinearForm.add_integrator(self.Lag_SSI)
+          
+    @variantmethod('implicit')
+    def lagrange_multiplier(self,A,b, uh0=None, phi_force=None):
+        """
+        Extend the matrix and the right-hand side vector
         
-    def lagrange_multiplier(self,A,b):
+        Parameters:
+            A (CSRTensor): The original matrix from the bilinear form.
+            b (TensorLike): The original right-hand side vector from the linear form.
+        Returns:
+            A (CSRTensor): The extended matrix with Lagrange multiplier terms.
+            b (TensorLike): The extended right-hand side vector with Lagrange multiplier terms.
+        """
         A0 = self.A0
         A1 = self.A1
         b0 = self.b0
@@ -172,6 +195,50 @@ class AllenCahnLFEMModel(ComputationalModel):
         A = A.assembly_sparse_matrix(format='csr')
         b  = bm.concatenate([b, b0], axis=0)
         return A, b
+    
+    @lagrange_multiplier.register('explicit')
+    def lagrange_multiplier(self,A,b, uh0=None, phi_force=None):
+        """
+        Explicitly add the Lagrange multiplier terms to right-hand side vector.
+        This method computes the Lagrange multiplier terms based on the current phase field variable and mesh movement.
+        
+        Parameters:
+            A (CSRTensor): The original matrix from the bilinear form.
+            b (TensorLike): The original right-hand side vector from the linear form.
+            uh0 (Function): The previous velocity field variable.
+            phi_force (Function): The force term for the phase field variable.
+        Returns:
+            A (CSRTensor): Without changing the matrix, only the right-hand side vector is extended.
+            b (TensorLike): The extended right-hand side vector with Lagrange multiplier terms.
+        """
+        space = self.space
+        bcs = self.bcs
+        pde = self.pde
+        gamma = pde.gamma()
+        dt = self.dt
+        eta = pde.eta
+        phi0 = self.phi0
+        rm = space.mesh.reference_cell_measure()
+        @barycentric
+        def G(bcs):
+            phi_val = phi0(bcs)
+            fphi = self.pde.nonlinear_source(phi_val)
+    
+            result = gamma * fphi
+            result += phi_force(bcs)
+            result += gamma* self.laplace_phi(bcs)
+            
+            mesh_result = self.move_vector(bcs) - uh0(bcs)
+            result += bm.einsum('cqi, cqi->cq', mesh_result, phi0.grad_value(bcs))
+            return result
+        node0 = self.mspace.function(self.node0.T.flatten())
+        J = node0.grad_value(bcs)
+        value = (1/dt + gamma/eta**2)*(bm.abs(bm.linalg.det(J))-1)*phi0(bcs) - G(bcs)
+        theta = 1/(gamma*pde.area)*bm.einsum('cq ,q ,cq ->',value,self.ws*rm,self.d)
+        self.Lag_SSI.source = dt*gamma*theta
+        b0 = self.LagLinearForm.assembly()
+        b += b0
+        return A,b
         
     def set_time_step(self, dt: float = 0.01):
         """
@@ -217,7 +284,8 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.mm.config.mol_times = moltimes
         self.mm.config.monitor = monitor
         self.mm.config.mol_meth = mol_meth
-        self.mm.config.is_pre = True
+        self.mm.config.pde = self.pde
+        self.mm.config.is_pre = False
         if config is not None:
             for key, value in config.items():
                 try:
@@ -235,6 +303,10 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.mspace = TensorFunctionSpace(smspace, (self.mesh.GD,-1))
         self.move_vector = self.mspace.function()
         self.time_step.set('moving_mesh')
+        if hasattr(self.space.mesh, 'jacobi_matrix'):
+            self._Jacobi = self.space.mesh.jacobi_matrix
+        else:
+            self._Jacobi = self.space.mesh.jacobian_matrix
     
     @variantmethod('forward')
     def set_linear_system(self):
@@ -252,8 +324,7 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.bform = BilinearForm(space)
         self.SMI = ScalarMassIntegrator(coef=1.0+dt*(gamma/eta**2), q=q, method=method)
         self.SDI = ScalarDiffusionIntegrator(coef=dt*gamma, q=q, method=method)
-        self.bform.add_integrator(self.SMI)
-        self.bform.add_integrator(self.SDI)
+        self.bform.add_integrator(self.SMI,self.SDI)
         self.set_linear_form()
         
         self.logger.info("Linear system set with bilinear and linear forms.")
@@ -279,9 +350,7 @@ class AllenCahnLFEMModel(ComputationalModel):
         self.SMI = ScalarMassIntegrator(coef=1.0+dt*(gamma/eta**2), q=q,method=method)
         self.SDI = ScalarDiffusionIntegrator(coef=dt*gamma, q=q, method=method)
         self.SCI = ScalarConvectionIntegrator(q=q, method=method)
-        self.bform.add_integrator(self.SMI)
-        self.bform.add_integrator(self.SDI)
-        self.bform.add_integrator(self.SCI)
+        self.bform.add_integrator(self.SMI,self.SDI, self.SCI)
         self.set_linear_form()
         
         self.logger.info("Linear system set with bilinear and linear forms.")
@@ -302,12 +371,12 @@ class AllenCahnLFEMModel(ComputationalModel):
         q = self.q
         method = self.assemble_method
         self.bform = BilinearForm(space)
+        self.bform_exp = BilinearForm(space)
         self.SMI = ScalarMassIntegrator(coef=1.0+dt*(gamma/eta**2), q=q, method=method)
+        self.SMI_exp = ScalarMassIntegrator(coef=1.0, q=q, method=method)
         self.SDI = ScalarDiffusionIntegrator(coef=dt*gamma, q=q, method=method)
-        # self.SCI = ScalarConvectionIntegrator(q=q, method=method)
-        self.bform.add_integrator(self.SMI)
-        self.bform.add_integrator(self.SDI)
-        # self.bform.add_integrator(self.SCI)
+        self.bform.add_integrator(self.SMI,self.SDI)
+        self.bform_exp.add_integrator(self.SMI_exp)
         self.set_linear_form()
         
         self.logger.info("Linear system set with bilinear and linear forms.")
@@ -322,6 +391,61 @@ class AllenCahnLFEMModel(ComputationalModel):
             self.set_move_mesher(**filtered_params)
         self.logger.info("Assembly method set to moving_mesh.")
         
+    @set_linear_system.register('moving_mesh_SDIRK')
+    def set_linear_system(self):
+        """
+        Set the linear system for the weak formulation of the Allen-Cahn equation with moving mesh.
+        """
+        space = self.space
+        q = self.q
+        method = self.assemble_method
+        self.bform0 = BilinearForm(space)
+        self.bform1 = BilinearForm(space)
+        self.SMI = ScalarMassIntegrator(q=q, method=method)
+        self.SDI = ScalarDiffusionIntegrator(q=q, method=method)
+        self.SCI = ScalarConvectionIntegrator(q=q, method=method)
+        self.bform0.add_integrator(self.SDI, self.SCI)
+        self.bform1.add_integrator(self.SMI)
+        self.set_linear_form()
+        
+        self.logger.info("Linear system set with bilinear and linear forms.")
+        self.logger.info("Bilinear form moving_mesh set with diffusion and mass terms.")
+        
+        if self.options['mm_param'] is None: 
+            self.set_move_mesher()
+        else:
+            valid_keys = {'mmesher', 'beta', 'tau', 'tmax', 'alpha', 'moltimes', 'monitor', 'mol_meth'}
+            filtered_params = {k: v for k, v in self.options['mm_param'].items() if k in valid_keys}
+            self.set_move_mesher(**filtered_params)
+        self.logger.info("Assembly method set to moving_mesh.")
+    
+    def laplace_recovery(self,phi0):
+        """
+        Compute the Laplacian recovery for the phase field variable.
+        
+        This method uses the L2 projector compute the Laplacian.
+        
+        Parameters:
+            phi0 (Function): The phase field variable function.
+        
+        Returns:
+            Function: The recovered Laplacian of the phase field variable.
+        """
+        space = self.space
+        bcs = self.bcs
+        grad_phi0 = phi0.grad_value(bcs)
+        grad_basis = space.grad_basis(bcs)
+        rm = space.mesh.reference_cell_measure()
+        J = self._Jacobi(bcs)
+        G = bm.permute_dims(J, (0, 1, 3,2))@ J
+        self.d = bm.sqrt(bm.linalg.det(G))
+        b_local = bm.einsum('q,cq,cqid, cqd->ci',self.ws*rm,self.d ,grad_basis,-grad_phi0)
+        F = bm.zeros(space.number_of_global_dofs(), dtype=bm.float64)
+        F = bm.index_add(F, space.cell_to_dof(), b_local)
+        M = self.bform_exp.assembly()
+        laplace_phi = space.function(self.solve(M, F))
+        return laplace_phi
+       
     def set_linear_form(self):
         """
         Set the linear form for the weak formulation of the Allen-Cahn equation.
@@ -351,22 +475,21 @@ class AllenCahnLFEMModel(ComputationalModel):
         eta = pde.eta
         gamma = pde.gamma()
         dt = self.dt
-        theta = self.theta # The Lagrange multiplier (default is 0).
 
         if hasattr(pde , 'phi_force'):
             phi_force = lambda p: pde.phi_force(p, t1)
+            phi_force = space.interpolate(phi_force)
         else:
             phi_force = space.function()
         
         @barycentric
         def source(bcs, index):
             phi_val = phi0(bcs, index)
-            f_force = space.interpolate(phi_force)
             fphi = pde.nonlinear_source(phi_val)
  
             result = (1+ dt*gamma/eta**2) * phi_val
             result -= gamma * dt * fphi
-            result += dt * f_force(bcs, index)
+            result += dt * phi_force(bcs, index)
 
             mesh_result = -uh0(bcs, index)
             result += dt*bm.einsum('cqi, cqi->cq', mesh_result, phi0.grad_value(bcs, index))
@@ -395,10 +518,10 @@ class AllenCahnLFEMModel(ComputationalModel):
         gamma = pde.gamma()
         bcs = self.bcs
         dt = self.dt
-        theta = self.theta # The Lagrange multiplier (default is 0).
 
         if hasattr(pde , 'phi_force'):
             phi_force = lambda p: pde.phi_force(p, t1)
+            phi_force = space.interpolate(phi_force)
         else:
             phi_force = space.function()
 
@@ -407,11 +530,10 @@ class AllenCahnLFEMModel(ComputationalModel):
         @barycentric
         def source(bcs, index):
             phi_val = phi0(bcs, index)
-            f_force = space.interpolate(phi_force)
             fphi = pde.nonlinear_source(phi_val)
             result = (1+ dt*gamma/eta**2) * phi_val
             result -= gamma * dt * fphi
-            result += dt * f_force(bcs, index)
+            result += dt * phi_force(bcs, index)
             return result
         self.SSI.source = source
 
@@ -439,25 +561,22 @@ class AllenCahnLFEMModel(ComputationalModel):
         space = self.space
         eta = pde.eta
         gamma = pde.gamma()
-        bcs = self.bcs
         dt = self.dt
-        theta = self.theta # The Lagrange multiplier (default is 0).
 
         if hasattr(pde , 'phi_force'):
             phi_force = lambda p: pde.phi_force(p, t1)
+            self.phi_force = space.interpolate(phi_force)
         else:
-            phi_force = space.function()
+            self.phi_force = space.function()
 
         @barycentric
         def source(bcs, index):
             phi_val = phi0(bcs, index)
-            # f_force = space.interpolate(phi_force)
             fphi = pde.nonlinear_source(phi_val)
- 
-            result = (1+ dt*gamma/eta**2) * phi_val
-            result -= gamma * dt * fphi
-            # result += dt * f_force(bcs, index)
-
+            result = -gamma * dt * fphi
+            result += gamma * dt * self.laplace_phi(bcs, index)
+            result += dt * self.phi_force(bcs, index)
+            
             mesh_result = move_vector(bcs,index) - uh0(bcs, index)
             result += dt*bm.einsum('cqi, cqi->cq', mesh_result, phi0.grad_value(bcs, index))
             return result
@@ -467,61 +586,6 @@ class AllenCahnLFEMModel(ComputationalModel):
         A = self.bform.assembly()
         b = self.lform.assembly()
         return A, b
-    
-    @variantmethod('explicit')
-    def lagrange_multi_solver(self,t1 = 0.0, phi0 = None, uh0 = None, mesh_vector = None):
-        """
-        Explicitly solve the Lagrange multiplier for the Allen-Cahn equation.
-        """
-        pde = self.pde
-        space = self.space
-        area = pde.area
-        gamma = pde.gamma()
-        eta = pde.eta
-        alpha = 1/self.dt + gamma/eta**2
-        NN = self.mesh.number_of_nodes()
-        GD = self.mesh.GD
-        if uh0 is None:
-            uh0 = self.uspace.interpolate(lambda p: pde.velocity_field(p, t=t1))
-        if phi0 is None:
-            phi0 = self.phi0
-        if mesh_vector is None:
-            mesh_vector = self.mspace.function()
-        if hasattr(pde , 'phi_force'):
-            phi_force = lambda p: pde.phi_force(p, t1)
-        else:
-            phi_force = space.function()
-
-        @barycentric
-        def G(bcs):
-            phi_val = phi0(bcs)
-            f_force = space.interpolate(phi_force)
-            fphi = pde.nonlinear_source(phi_val)
-            grad_phi0 = phi0.grad_value(bcs)
-            cell_grad = bm.mean(grad_phi0, axis=1)
-            vertex_grad = bm.zeros((NN, GD))
-            vertex_count = bm.zeros(NN)
-            cell2dof = space.cell_to_dof()
-            vertex_grad = bm.index_add(vertex_grad, cell2dof, cell_grad[:, None])
-            vertex_count = bm.index_add(vertex_count, cell2dof, 1)
-            vertex_grad /= vertex_count[:, None] 
-
-            grad_basis = space.grad_basis(bcs)
-            laplace_phi0 = bm.einsum('cqid, cid->cq', grad_basis, vertex_grad[cell2dof])
-            result = gamma * fphi
-            result += f_force(bcs)
-            result += gamma* laplace_phi0
-
-            mesh_result = mesh_vector(bcs) - uh0(bcs)
-            result += bm.einsum('cqi, cqi->cq', mesh_result, grad_phi0)
-            return result
-        
-        node0 = self.mspace.function(self.node0.T.flatten())
-        bcs,ws = self.bcs, self.ws
-        cm = self.mesh.entity_measure('cell')
-        J = bm.abs(node0.grad_value(bcs))
-        value = alpha*(bm.linalg.det(J)-1)*phi0(bcs) - G(bcs)
-        self.theta = 1/(gamma*area)*bm.einsum('cq ,q ,c ->',value , ws,cm)
 
     @variantmethod("direct")
     def solve(self,A,b):
@@ -570,11 +634,9 @@ class AllenCahnLFEMModel(ComputationalModel):
         """
         self.uh0[:] = self.uspace.interpolate(lambda p: self.pde.velocity_field(p, t=self.t))
         A,b = self.assembly(t1 = self.t,uh0=self.uh0,phi0=self.phi0)
-        if self.is_Lag_muliplier:
-            A,b = self.lagrange_multiplier(A, b)
-            phi_new = self.solve(A,b)[:-1]
-        else:
-            phi_new = self.solve(A,b)
+
+        A,b = self.lagrange_multiplier(A, b)
+        phi_new = self.solve(A,b)[:-1]
         
         self.phi[:] = phi_new
         self.phi0[:] = self.phi[:]
@@ -590,25 +652,104 @@ class AllenCahnLFEMModel(ComputationalModel):
         mm = self.mm
         mm.run()
         if self.t-self.dt == 0.0:
+            mm.set_interpolation_method('solution')
             self.node0 = self.mesh.node.copy()
-            self.phi0[:] = self.space.interpolate(lambda p:self.pde.init_solution(p, t=self.t-self.dt))
-
+            self.phi0[:] = self.space.interpolate(lambda p:self.pde.init_condition(p, t=self.t-self.dt))
+            mm.set_interpolation_method('linear')
         self.move_vector[:] = ((self.mesh.node - self.node0)/self.dt).T.flatten()
         self.uh0[:] = self.uspace.interpolate(lambda p: self.pde.velocity_field(p, t=self.dt))
+        
+        self.laplace_phi = self.laplace_recovery(self.phi0)
+        A,b = self.assembly(t1 = self.t,uh0 = self.uh0,phi0=self.phi0,move_vector = self.move_vector)
+        A,b = self.lagrange_multiplier(A, b, uh0=self.uh0, phi_force=self.phi_force)
 
-        A,b = self.assembly(t1 = self.t,uh0=self.uh0,phi0=self.phi0,move_vector = self.move_vector)
-        if self.is_Lag_muliplier:
-            self.set_lagrange_multiplier()
-            A,b = self.lagrange_multiplier(A, b)
-            phi_new = self.solve(A,b)[:-1]
-        else:
-            phi_new = self.solve(A,b)
+        phi_e = self.solve(A,b)
+        phi_new = self.phi0 + phi_e
 
         self.phi[:] = phi_new
         self.phi0[:] = self.phi[:]
         self.node0 = self.mesh.node.copy()
-        self.mm.instance.uh = phi_new
+        self.mm.instance.uh = phi_new.copy()
     
+    @time_step.register('moving_mesh_SDIRK')
+    def time_step(self):
+        """
+        Perform a time step for the Allen-Cahn phase field model using the SDIRK method.
+        
+        This method updates the phase field variable using the SDIRK method, which is suitable for stiff problems.
+        """
+        sub_steps = 30
+        r = 1- bm.sqrt(2)/2
+        tau1 = r
+        tau2 = 1
+        a11 = r
+        a21 = 1-r
+        a22 = r
+        b1 = 1-r
+        b2 = r
+        mm = self.mm
+        mm.run()
+        dt = self.dt
+        if self.t-dt == 0.0:
+            sub_steps = 30
+            self.node0 = self.mesh.node.copy()
+            self.phi0[:] = self.space.interpolate(lambda p:self.pde.init_condition(p, t=self.t-self.dt))
+        else:
+            sub_steps = 3
+        
+        delta = dt/(sub_steps)    
+        v = (self.mesh.node - self.node0)/self.dt
+        self.move_vector[:] = (v).T.flatten()
+        for i in range(sub_steps):
+            t_hat = self.t + (i)*delta
+            self.mesh.node = self.node0 + tau1*delta * v
+            M = self.bform1.assembly()
+            self.SDI.coef = delta * self.pde.gamma() *a11
+            self.SCI.coef = -delta * self.move_vector *a11
+            def source(bcs,index):
+                phi_val = self.phi0(bcs, index)
+                f_val = self.pde.nonlinear_source(phi_val)
+                result =  phi_val
+                result -= a11* delta * self.pde.gamma() * f_val
+                return result
+            
+            self.SSI.source = source
+            A = self.bform0.assembly() 
+            A += M
+            b = self.lform.assembly()
+            
+            self.set_lagrange_multiplier()
+            A,b = self.lagrange_multiplier(A, b)
+            phi1 = self.solve(A, b)[:-1]
+            
+            self.mesh.node = self.node0 + delta * v
+            phi1 = self.space.function(phi1)
+            k1 = (phi1 - self.phi0)/(tau1*delta)
+            self.SDI.coef = self.pde.gamma()*delta*a22
+            self.SCI.coef = -delta * self.move_vector*a22
+            def source(bcs,index):
+                result = delta*a21*k1.value(bcs, index)
+                result += self.phi0(bcs, index)
+                
+                phi_val = self.phi0(bcs, index)
+                f_val = self.pde.nonlinear_source(phi_val)
+                result -= a22* delta * self.pde.gamma() * f_val
+                return result
+            self.SSI.source = source
+            A = self.bform0.assembly()
+            M = self.bform1.assembly()
+            A += M
+            b = self.lform.assembly()
+            self.set_lagrange_multiplier()
+            A,b = self.lagrange_multiplier(A, b)
+            phi2 = self.solve(A, b)[:-1]
+            
+            k2 = (phi2 - self.phi0 - delta*a21*k1)/(a22*delta)
+            self.phi[:] = self.phi0 + delta*b1*k1 + delta*b2*k2
+            self.phi0[:] = self.phi[:]
+            self.node0 = self.mesh.node.copy()
+        self.mm.instance.uh = self.phi.copy()
+                   
     def run(self,save_vtu_enabled: bool = False,error_estimate_enabled: bool = False):
         """
         Run the time-stepping loop for the Allen-Cahn phase field model.
@@ -617,7 +758,7 @@ class AllenCahnLFEMModel(ComputationalModel):
         and moving the mesh if necessary.
         """
         self.logger.info("Starting time-stepping loop.")
-        
+        self.error_estimate_enabled = error_estimate_enabled
         step = 0
         while self.t < self.pde.duration()[1]:
             self.t += self.dt
@@ -627,7 +768,7 @@ class AllenCahnLFEMModel(ComputationalModel):
             if save_vtu_enabled:
                 self.save_vtu(step)
 
-            if error_estimate_enabled:
+            if self.error_estimate_enabled:
                 error = self.error_estimate()
                 
             step += 1
@@ -657,7 +798,7 @@ class AllenCahnLFEMModel(ComputationalModel):
         """
         if not hasattr(self.pde, 'solution'):
             self.logger.warning("pde.solution is not defined. Disabling error estimation.")
-            error_estimate_enabled = False
+            self.error_estimate_enabled = False
             return 0.0
         
         pde = self.pde

--- a/fealpy/mmesh/base.py
+++ b/fealpy/mmesh/base.py
@@ -1,5 +1,6 @@
 from .config import *
 from .tool import _solve_quad_parametric_coords
+from ..decorator import variantmethod
 
 class MM_PREProcessor:
     def __init__(self,mesh:_U,space:_V,config:Config) -> None:
@@ -691,6 +692,7 @@ class MM_PREProcessor:
         Returns
             method: corresponding method object
         """
+        print(f"Getting method: {method_name}")
         if hasattr(self, method_name):
             return getattr(self, method_name)
         else:
@@ -705,47 +707,8 @@ class MM_monitor(MM_PREProcessor):
         self.alpha = config.alpha
         self.mol_times = config.mol_times
 
-        self.monitor = config.monitor
-        self.mol_meth = config.mol_meth
-
-    @property
-    def monitor(self):
-        return self._monitor_name
-
-    @monitor.setter
-    def monitor(self, name: str):
-        """
-        setting monitor and dynamically update _mot_meth
-        """
-        self._mot_meth = self._get_method(name)
-        self._monitor_name = name
-
-    @property
-    def mol_meth(self):
-        return self._mol_meth_name
-
-    @mol_meth.setter
-    def mol_meth(self, name: str):
-        """
-        setting mol_meth and dynamically update _mol_meth
-        """
-        self._mol_meth = self._get_method(name)
-        self._mol_meth_name = name
-
-    def mot(self):
-        """
-        manager of the monitor and mollification method
-        """
-        self._mot_meth() # monitor method
-        self._mol_meth() # mollification method
-
-    def mp_mot(self):
-        """
-        manager of the monitor and mollification method for multiphysics
-        """
-
-        self._mot_meth()
-        self._mol_meth()
+        # self.monitor = config.monitor
+        # self.mol_meth = config.mol_meth
     
     def _grad_uh(self):
         """
@@ -775,14 +738,16 @@ class MM_monitor(MM_PREProcessor):
         guh_incell = bm.einsum('cqid , cil -> cqld ',gphi,uh[pcell2dof])
         return guh_incell
 
-    def arc_length(self):
+    @variantmethod('arc_length')
+    def monitor(self):
         """
         arc length monitor
         """
         guh_incell = self._grad_uh()
         self.M = bm.sqrt(1 +  self.beta * bm.sum(guh_incell**2,axis=-1))
-
-    def arc_length_norm(self):
+        
+    @monitor.register('norm_arc_length')
+    def monitor(self):
         """
         normalized arc length monitor
         """
@@ -792,7 +757,8 @@ class MM_monitor(MM_PREProcessor):
             R = 1
         self.M = bm.sqrt(1 + self.beta * bm.sum(guh_incell**2,axis=-1)/R**2)
     
-    def mp_arc_length(self):
+    @monitor.register('mp_arc_length')
+    def monitor(self):
         """
         arc length monitor for multiphysics
         """
@@ -800,7 +766,8 @@ class MM_monitor(MM_PREProcessor):
         self.M = bm.sqrt(1 + 1/self.dim*bm.sum(self.beta[None,None,:]*
                                    bm.sum(guh_incell**2,axis=-1),axis=-1))
 
-    def matrix_normal(self):
+    @monitor.register('matrix_normal')
+    def monitor(self):
         """
         matrix normal monitor method
         """
@@ -825,7 +792,36 @@ class MM_monitor(MM_PREProcessor):
         self.M = lambda_1[...,None,None]*v[...,None,:]*v[...,None] + \
                  lambda_1[...,None,None]*v_orth[...,None,:]*v_orth[...,None] # NC,NQ,TD,TD
 
-    def heatequ(self):
+    @variantmethod('projector')
+    def mol_method(self):
+        """
+        projection operator mollification method
+        """
+        M = self.M
+        exp_nd = M.ndim - 2
+        cell2dof = self.cell2dof  # NC,NQ
+        sm = self.sm
+        d = self.d # NC,NQ
+        rm = self.rm
+        exp_sm = sm[(...,) + (None,) * exp_nd]
+        shape = (self.NN,) + (self.TD,) * exp_nd
+        phi = self.mspace.basis(self.bcs)
+        dphi = phi*rm*d[(...,) + (None,) *(3-d.ndim)]  # NC,NQ,...
+        M = M*rm*d[(...,) + (None,) * (2-d.ndim+exp_nd)]  # NC,NQ,...
+        M_node = bm.zeros(shape, **self.kwargs0)
+        for i in range(self.mol_times):
+            if i != 0:
+                M = bm.einsum('cqi,ci...->cq...', dphi, M_node[cell2dof])
+            M_incell = bm.einsum('cq...,q-> c...',M,self.ws)
+            M_node.fill(0)
+            M_node = bm.index_add(M_node, cell2dof, M_incell[:,None,...])
+            M_node /= exp_sm
+            
+        self.M = bm.einsum('cqi,ci...->cq...', phi, M_node[cell2dof])
+        self.M_node = M_node
+    
+    @mol_method.register('heat_equ')
+    def mol_method(self):
         """
         heat equation mollification method
         """
@@ -855,33 +851,6 @@ class MM_monitor(MM_PREProcessor):
             M = M_bar(self.bcs)
         self.M = M
 
-    def projector(self):
-        """
-        projection operator mollification method
-        """
-        M = self.M
-        exp_nd = M.ndim - 2
-        cell2dof = self.cell2dof  # NC,NQ
-        sm = self.sm
-        d = self.d # NC,NQ
-        rm = self.rm
-        exp_sm = sm[(...,) + (None,) * exp_nd]
-        shape = (self.NN,) + (self.TD,) * exp_nd
-        phi = self.mspace.basis(self.bcs)
-        dphi = phi*rm*d[(...,) + (None,) *(3-d.ndim)]  # NC,NQ,...
-        M = M*rm*d[(...,) + (None,) * (2-d.ndim+exp_nd)]  # NC,NQ,...
-        M_node = bm.zeros(shape, **self.kwargs0)
-        for i in range(self.mol_times):
-            if i != 0:
-                M = bm.einsum('cqi,ci...->cq...', dphi, M_node[cell2dof])
-            M_incell = bm.einsum('cq...,q-> c...',M,self.ws)
-            M_node.fill(0)
-            M_node = bm.index_add(M_node, cell2dof, M_incell[:,None,...])
-            M_node /= exp_sm
-            
-        self.M = bm.einsum('cqi,ci...->cq...', phi, M_node[cell2dof])
-        self.M_node = M_node
-
 
 class MM_Interpolater(MM_PREProcessor):
     def __init__(self, mesh,space, config: Config):
@@ -895,31 +864,9 @@ class MM_Interpolater(MM_PREProcessor):
         elif self.mesh_type == "QuadrangleMesh":
             self.interpolate_batch = self._quad_interpolate_batch
             self.high_order_batch = self._quad_high_order_interpolate
-    @property
-    def int_meth(self):
-        """
-        only for get the int_meth name
-        """
-        return self._int_meth_name
 
-    @int_meth.setter
-    def int_meth(self, name: str):
-        """
-        when int_meth is set, update _int_meth dynamically
-        """
-        self._int_meth = self._get_method(name)
-        self._int_meth_name = name
-
+    @variantmethod('comass')
     def interpolate(self,moved_node:TensorLike):
-        """
-        interpolate the solution,the method is determined by the int_meth
-        
-        Parameters
-            moved_node: TensorLike, new node positions
-        """
-        self.uh = self._int_meth(moved_node)
-
-    def comass(self,moved_node:TensorLike):
         """
         conservation of mass interpolation method
         
@@ -960,7 +907,8 @@ class MM_Interpolater(MM_PREProcessor):
         sol = bm.asarray(sol,**self.kwargs0)
         return sol
 
-    def linear_interpolate(self, moved_node: TensorLike):
+    @interpolate.register('linear')
+    def interpolate(self, moved_node: TensorLike):
         """
         linear interpolation method
         
@@ -1001,8 +949,8 @@ class MM_Interpolater(MM_PREProcessor):
             print(f"Warning: Maximum iterations reached ({max_iterations}) without full interpolation.")
         
         new_uh = self.high_order_batch(new_uh, p)  # 高阶插值处理
-        self.uh = new_uh
-
+        return new_uh
+        
     def _tri_interpolate_batch(self,nodes, cells,new_uh, interpolated,moved_node):
         """
         triangle mesh interpolation batch processing
@@ -1138,7 +1086,8 @@ class MM_Interpolater(MM_PREProcessor):
         
         return value
 
-    def mp_comass(self,moved_node:TensorLike):
+    @interpolate.register('mp_comass')
+    def interpolate(self,moved_node:TensorLike):
         """
         conservation of mass interpolation method for multiphysics
         
@@ -1178,7 +1127,8 @@ class MM_Interpolater(MM_PREProcessor):
             sol = bm.set_at(sol,(...,i),s)
         return sol
     
-    def solution(self,moved_node:TensorLike):
+    @interpolate.register('solution')
+    def interpolate(self,moved_node:TensorLike):
         """
         get the solution
         
@@ -1190,7 +1140,8 @@ class MM_Interpolater(MM_PREProcessor):
         pde = self.pde
         return pde.init_solution(moved_node)
     
-    def poisson(self,moved_node:TensorLike):
+    @interpolate.register('poisson')
+    def interpolate(self,moved_node:TensorLike):
         """
         poisson interpolation method
         
@@ -1218,7 +1169,8 @@ class MM_Interpolater(MM_PREProcessor):
         A, b = bc.apply(A, b)
         return spsolve(A, b, solver=self.solver)
     
-    def convect_diff(self,moved_node:TensorLike):
+    @interpolate.register('convect_diff')
+    def interpolate(self,moved_node:TensorLike):
         """
         convection diffusion interpolation method
         

--- a/fealpy/mmesh/gfmmpde.py
+++ b/fealpy/mmesh/gfmmpde.py
@@ -439,7 +439,8 @@ class GFMMPDE(MM_monitor,MM_Interpolater):
         """
         old_M = None
         for i in range(maxit):
-            self.mot()
+            self.monitor()
+            self.mol_method()
             self.monitor_time_smooth(old_M)
 
             node = self.func_solver()
@@ -448,14 +449,11 @@ class GFMMPDE(MM_monitor,MM_Interpolater):
             
             error = bm.max(bm.linalg.norm(node - self.node,axis=1))
             print(f"iteration {i} , error: {error}")
-            self.linear_interpolate(node)
+            self.uh = self.interpolate(node)
             old_M = self.M.copy()
             self.construct(node)
-            
             if error < self.tol:
-                break
-
-            
+                break       
             
     def preprocessor(self,fun_solver =None):
         """

--- a/fealpy/mmesh/mmesher.py
+++ b/fealpy/mmesh/mmesher.py
@@ -1,7 +1,9 @@
 from .config import *
 from concurrent.futures import ProcessPoolExecutor,ThreadPoolExecutor,as_completed
+from ..model import ComputationalModel
 
-class MMesher:
+
+class MMesher(ComputationalModel):
     registered_param = {}
     def __init__(self,
                  mesh: Union[_U,list] ,
@@ -18,6 +20,7 @@ class MMesher:
         @param beta: parameter of the monitor function
         @param vertices: vertices of the domain
         """
+        super().__init__(pbar_log=True, log_level="INFO")
         self.mesh = mesh
         self.uh = uh
         self.space = space
@@ -29,6 +32,7 @@ class MMesher:
         self.dim = 1
 
         self._check()
+        
     def _check(self):
         if isinstance(self.mesh, list) and len(self.mesh) == 1:
             self.mesh = self.mesh[0]
@@ -72,6 +76,45 @@ class MMesher:
             self.config.monitor = 'mp_arc_length'
             self.config.int_meth = 'mp_comass'
 
+    def set_interpolation_method(self, method_name: str):
+        """
+        Set the interpolation method dynamically.
+        
+        Parameters:
+            method_name: The name of the interpolation method to set.
+                    It should be a string that matches a registered method.
+        """
+        if not isinstance(method_name, str):
+            raise TypeError("method_name must be a string")
+        self.logger.info(f"Setting interpolation method to: {method_name}")
+        self.instance.interpolate.set(method_name)
+    
+    def set_monitor(self, method_name: str):
+        """
+        Set the monitor dynamically.
+        
+        Parameters:
+            method_name: The name of the monitor to set.
+                    It should be a string that matches a registered method.
+        """
+        if not isinstance(method_name, str):
+            raise TypeError("method_name must be a string")
+        self.logger.info(f"Setting monitor method to: {method_name}")
+        self.instance.monitor.set(method_name)
+        
+    def set_mol_method(self, method_name: str):
+        """
+        Set the method of the method of lines dynamically.
+        
+        Parameters:
+            method_name: The name of the method to set.
+                    It should be a string that matches a registered method.
+        """
+        if not isinstance(method_name, str):
+            raise TypeError("method_name must be a string")
+        self.logger.info(f"Setting method of lines to: {method_name}")
+        self.instance.mol_method.set(method_name)
+        
     def register(self, parameters: dict):
         """
         Register or update parameters.
@@ -95,6 +138,7 @@ class MMesher:
             for key, value in parameters.items():
                 setattr(self.config, key, value)  
                 self._update_recursive(self.instance, key, value)
+
         self._initialize_param()
         self._check()
 

--- a/fealpy/model/allen_cahn/circle_interface_data_2d.py
+++ b/fealpy/model/allen_cahn/circle_interface_data_2d.py
@@ -82,6 +82,20 @@ class CircleInterfaceData2D:
         mesh.nodedata['vertices'] = vertices
         return mesh
     
+    @init_mesh.register('moving_tri_unstru')
+    def init_mesh(self, **kwargs):
+        domain = self.box
+        vertices = bm.array([[domain[0], domain[2]],
+                             [domain[1], domain[2]],
+                             [domain[1], domain[3]],
+                             [domain[0], domain[3]]], **kwargs)
+
+        from ...mesh import TriangleMesh
+        h = 0.04
+        mesh = TriangleMesh.from_polygon_gmsh(vertices=vertices,h=h, **kwargs)
+        mesh.nodedata['vertices'] = vertices
+        return mesh
+    
     def duration(self) -> Sequence[float]:
         """the time interval [t0, t1]."""
         return [0.0, 5000.0]
@@ -102,7 +116,7 @@ class CircleInterfaceData2D:
         return bm.zeros_like(p, dtype=bm.float64)
 
     @cartesian
-    def init_solution(self, p: TensorLike,t = 0.0) -> TensorLike:
+    def init_condition(self, p: TensorLike,t = 0.0) -> TensorLike:
         x = p[..., 0]
         y = p[..., 1]
         r = bm.sqrt((x)**2 + (y)**2)

--- a/fealpy/model/allen_cahn/sincoscos_data_2d.py
+++ b/fealpy/model/allen_cahn/sincoscos_data_2d.py
@@ -116,7 +116,7 @@ class SinCosCosData2D:
         return val
     
     @cartesian
-    def init_solution(self, p: TensorLike, t: float = 0.0) -> TensorLike:
+    def init_condition(self, p: TensorLike, t: float = 0.0) -> TensorLike:
         """Return the initial condition for the phase field."""
         return self.solution(p, t)
     

--- a/fealpy/model/pde_data_manager.py
+++ b/fealpy/model/pde_data_manager.py
@@ -45,7 +45,7 @@ class PDEDataManager:
         "hyperbolic": "fealpy.model.hyperbolic",
         "nonlinear": "fealpy.model.nonlinear",
         "linear_elasticity": "fealpy.model.linear_elasticity",
-        "helmholtz": "fealpy.model.helmholtz"
+        "helmholtz": "fealpy.model.helmholtz",
         "allen_cahn": "fealpy.model.allen_cahn",
     }
 


### PR DESCRIPTION
[Feat] Add the a new explicit Lagrange multiplier computation method in fem/allencahn_lfem_model

Describe: Renamed the original computation method to implicit computation, unified under the set_lagrange_multiplier setup and lagrange_multiplier assembly sections, and modified the single time-step logic.

[Feat] Added a temporary Laplace recovery scheme in fem/allencahn_lfem_model.

[Feat] Added a temporary SDIRK time-stepping strategy in fem/allencahn_lfem_model for testing purposes.

[Fix] Modified the error computation logic to disable related calculations when no exact solution is available.

[Fix] Fixed a bug in the logic for determining external force terms during assembly.

[Fix] Unified the initial condition naming in the allencahn PDE model to init_condition.

[Chore] Updated the external interface for Lagrange multipliers, removing the need for execution checks. It now defaults to always required and allows setting either the implicit or explicit method.

[Refactor] Refactored parts of the moving mesh logic in mmesh.

Describe:
Rewrote the registration logic for control functions, smoothing methods, and interpolation methods using variant decorators. Added external set methods in the mmesher class to include the above registrations.